### PR TITLE
Refactor/#1/profile drop

### DIFF
--- a/SniffMeet/SNMSceneTests/MateListScene/UseCaseMock.swift
+++ b/SniffMeet/SNMSceneTests/MateListScene/UseCaseMock.swift
@@ -37,7 +37,7 @@ final class TryProfileDropUseCaseMock: TryProfileDropUseCase {
     var profilePublisher: CurrentValueSubject<DogDTO?, Never> = CurrentValueSubject(nil)
     var isNIConnected: CurrentValueSubject<Bool, Never> = CurrentValueSubject(false)
     var transmissionFlag: Set<String> = []
-    var isTransistioned: Bool = false
+    var isTransitioned: Bool = false
     var triedBefore: Bool = false
     
     init() {

--- a/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
@@ -24,7 +24,11 @@ enum Environment {
     enum FileManagerKey {
         static let profileImage: String = "profile"
     }
-    
+
+    enum LocalNetworkKey {
+        static let defaultPeerName: String = "SniffMeet"
+    }
+
     enum SupabaseTableName {
         static let userInfo = "user_info"
         static let notification = "notification"

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
@@ -8,24 +8,32 @@ import MultipeerConnectivity
 import os
 
 final class MPCAdvertiser {
-    let advertiser: MCNearbyServiceAdvertiser
+    var advertiser: MCNearbyServiceAdvertiser
     let session: MCSession
-    let myPeerID: MCPeerID
-    
+    var myPeerID: MCPeerID
+    let serviceType: String
+
     init(advertiser: MCNearbyServiceAdvertiser,
          session: MCSession,
-         myPeerID: MCPeerID)
+         myPeerID: MCPeerID,
+         serviceType: String)
     {
         self.advertiser = advertiser
         self.session = session
         self.myPeerID = myPeerID
+        self.serviceType = serviceType
     }
     
     convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
         let newAdvertiser = MCNearbyServiceAdvertiser(peer: myPeerID,
                                                       discoveryInfo: nil,
                                                       serviceType: serviceType)
-        self.init(advertiser: newAdvertiser, session: session, myPeerID: myPeerID)
+        self.init(
+            advertiser: newAdvertiser,
+            session: session,
+            myPeerID: myPeerID,
+            serviceType: serviceType
+        )
         SNMLogger.log("Created new MCNearbyServiceAdvertiser instance")
     }
     func startAdvertising() {
@@ -36,5 +44,11 @@ final class MPCAdvertiser {
     func stopAdvertising() {
         advertiser.stopAdvertisingPeer()
         SNMLogger.log("stop advertising")
+    }
+    func setMyPeerID(peerID: MCPeerID) {
+        myPeerID = peerID
+        advertiser = MCNearbyServiceAdvertiser(peer: myPeerID,
+                                               discoveryInfo: nil,
+                                               serviceType: serviceType)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
@@ -45,5 +45,4 @@ final class MPCAdvertiser {
         advertiser.stopAdvertisingPeer()
         SNMLogger.log("stop advertising")
     }
-    }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
@@ -8,14 +8,14 @@ import Combine
 import MultipeerConnectivity
 import os
 
-final class MPCAdvertiser: NSObject {
+final class MPCAdvertiser {
     let advertiser: MCNearbyServiceAdvertiser
     let session: MCSession
     let myPeerID: MCPeerID
 
     static var sharedAdvertiser: MCNearbyServiceAdvertiser?
 
-    var receivedInvite = PassthroughSubject<Bool, Never>()
+//    var receivedInvite = PassthroughSubject<Bool, Never>()
 
     @Published var receivedInviteFrom: MCPeerID?
     @Published var invitationHandler: ((Bool, MCSession?) -> Void)?
@@ -31,9 +31,6 @@ final class MPCAdvertiser: NSObject {
         self.myPeerID = myPeerID
         self.receivedInviteFrom = receivedInviteFrom
         self.invitationHandler = invitationHandler
-        
-        super.init()
-        advertiser.delegate = self
     }
     
     convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
@@ -63,24 +60,7 @@ final class MPCAdvertiser: NSObject {
     
     func stopAdvertising() {
         advertiser.stopAdvertisingPeer()
-        receivedInvite.send(false)
+//        receivedInvite.send(false)
         SNMLogger.log("stop advertising")
-    }
-}
-
-extension MPCAdvertiser: MCNearbyServiceAdvertiserDelegate {
-    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
-                    didNotStartAdvertisingPeer error: Error) {
-        SNMLogger.info("Advertiser failed to start: \(error)")
-    }
-
-    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
-                    didReceiveInvitationFromPeer peerID: MCPeerID,
-                    withContext context: Data?,
-                    invitationHandler: @escaping (Bool, MCSession?) -> Void)
-    {
-        SNMLogger.info("Received invitation from \(peerID)")
-        invitationHandler(true, session)
-        receivedInvite.send(true)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
@@ -45,10 +45,5 @@ final class MPCAdvertiser {
         advertiser.stopAdvertisingPeer()
         SNMLogger.log("stop advertising")
     }
-    func setMyPeerID(peerID: MCPeerID) {
-        myPeerID = peerID
-        advertiser = MCNearbyServiceAdvertiser(peer: myPeerID,
-                                               discoveryInfo: nil,
-                                               serviceType: serviceType)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
@@ -4,7 +4,6 @@
 //
 //  Created by 윤지성 on 11/13/24.
 //
-import Combine
 import MultipeerConnectivity
 import os
 
@@ -12,47 +11,23 @@ final class MPCAdvertiser {
     let advertiser: MCNearbyServiceAdvertiser
     let session: MCSession
     let myPeerID: MCPeerID
-
-    static var sharedAdvertiser: MCNearbyServiceAdvertiser?
-
-//    var receivedInvite = PassthroughSubject<Bool, Never>()
-
-    @Published var receivedInviteFrom: MCPeerID?
-    @Published var invitationHandler: ((Bool, MCSession?) -> Void)?
-
+    
     init(advertiser: MCNearbyServiceAdvertiser,
          session: MCSession,
-         myPeerID: MCPeerID,
-         receivedInviteFrom: MCPeerID? = nil,
-         invitationHandler: ((Bool, MCSession?) -> Void)? = nil)
+         myPeerID: MCPeerID)
     {
         self.advertiser = advertiser
         self.session = session
         self.myPeerID = myPeerID
-        self.receivedInviteFrom = receivedInviteFrom
-        self.invitationHandler = invitationHandler
     }
     
     convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
-        if let existingAdvertiser = MPCAdvertiser.sharedAdvertiser {
-            self.init(advertiser: existingAdvertiser, session: session, myPeerID: myPeerID)
-        } else {
-            let newAdvertiser = MCNearbyServiceAdvertiser(peer: myPeerID,
-                                                          discoveryInfo: nil,
-                                                          serviceType: serviceType)
-            MPCAdvertiser.sharedAdvertiser = newAdvertiser
-            self.init(advertiser: newAdvertiser, session: session, myPeerID: myPeerID)
-            SNMLogger.log("Created new MCNearbyServiceAdvertiser instance")
-        }
+        let newAdvertiser = MCNearbyServiceAdvertiser(peer: myPeerID,
+                                                      discoveryInfo: nil,
+                                                      serviceType: serviceType)
+        self.init(advertiser: newAdvertiser, session: session, myPeerID: myPeerID)
+        SNMLogger.log("Created new MCNearbyServiceAdvertiser instance")
     }
-
-    deinit {
-        if MPCAdvertiser.sharedAdvertiser === advertiser {
-            MPCAdvertiser.sharedAdvertiser = nil
-            SNMLogger.log("MPCAdvertiser deinit")
-        }
-    }
-
     func startAdvertising() {
         advertiser.startAdvertisingPeer()
         SNMLogger.log("start advertising")
@@ -60,7 +35,6 @@ final class MPCAdvertiser {
     
     func stopAdvertising() {
         advertiser.stopAdvertisingPeer()
-//        receivedInvite.send(false)
         SNMLogger.log("stop advertising")
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -7,14 +7,13 @@
 import MultipeerConnectivity
 import os
 
-final class MPCBrowser: NSObject {
+final class MPCBrowser {
     let browser: MCNearbyServiceBrowser
     let session: MCSession
     let myPeerId: MCPeerID
 
     static var sharedBrowser: MCNearbyServiceBrowser?
 
-    var availablePeers = Set<MCPeerID>()
 
     init(browser: MCNearbyServiceBrowser,
          session: MCSession,
@@ -23,9 +22,7 @@ final class MPCBrowser: NSObject {
         self.browser = browser
         self.session = session
         self.myPeerId = myPeerId
-        
-        super.init()
-        browser.delegate = self
+
     }
     
     convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
@@ -54,14 +51,7 @@ final class MPCBrowser: NSObject {
     
     func stopBrowsing() {
         browser.stopBrowsingForPeers()
-        availablePeers.removeAll()
         SNMLogger.log("stop Browsing")
-    }
-    
-    func invite() {
-        guard let peer = availablePeers.first else { return }
-        browser.invitePeer(peer, to: session, withContext: nil, timeout: 30)
-        SNMLogger.log("invitePeer")
     }
 
     func invite(peerID: MCPeerID) {
@@ -72,34 +62,5 @@ final class MPCBrowser: NSObject {
     func invite(peerID: MCPeerID, tokenData: Data) {
         browser.invitePeer(peerID, to: session, withContext: tokenData, timeout: 30)
         SNMLogger.log("invitePeer tokenData")
-    }
-}
-
-extension MPCBrowser: MCNearbyServiceBrowserDelegate {
-    func browser(_ browser: MCNearbyServiceBrowser,
-                 foundPeer peerID: MCPeerID,
-                 withDiscoveryInfo info: [String : String]?)
-    {
-        if let info = info {
-            SNMLogger.info("Found peer with info: \(info)")
-        }
-        
-        // info에 해당되는 peer에 대해서만 availablepeers에 넣을 수 있다
-        SNMLogger.info("ServiceBrowser found peer: \(peerID)")
-        guard !(self.availablePeers.contains(peerID)) else { return }
-        self.availablePeers.insert(peerID)
-
-        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
-            if (self?.session.connectedPeers.contains(peerID) == false) {
-                self?.invite(peerID: peerID)
-            }
-        }
-        SNMLogger.info("availablePeers: \(self.availablePeers)")
-    }
-    
-    
-    func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        guard let index = availablePeers.firstIndex(of: peerID) else { return }
-        self.availablePeers.remove(at: index)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -50,9 +50,5 @@ final class MPCBrowser {
         browser.invitePeer(peerID, to: session, withContext: tokenData, timeout: 30)
         SNMLogger.log("invitePeer tokenData")
     }
-    func setMyPeerID(peerID: MCPeerID) {
-        myPeerId = peerID
-        browser = MCNearbyServiceBrowser(peer: myPeerId,
-                                         serviceType: serviceType)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -11,10 +11,7 @@ final class MPCBrowser {
     let browser: MCNearbyServiceBrowser
     let session: MCSession
     let myPeerId: MCPeerID
-
-    static var sharedBrowser: MCNearbyServiceBrowser?
-
-
+    
     init(browser: MCNearbyServiceBrowser,
          session: MCSession,
          myPeerId: MCPeerID)
@@ -22,43 +19,25 @@ final class MPCBrowser {
         self.browser = browser
         self.session = session
         self.myPeerId = myPeerId
-
+    }
+    convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
+        let newBrowser = MCNearbyServiceBrowser(peer: myPeerID,
+                                                serviceType: serviceType)
+        self.init(browser: newBrowser, session: session, myPeerId: myPeerID)
     }
     
-    convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
-        if let existingBrowser = MPCBrowser.sharedBrowser {
-            self.init(browser: existingBrowser, session: session, myPeerId: myPeerID)
-        } else {
-            let newBrowser = MCNearbyServiceBrowser(peer: myPeerID,
-                                                    serviceType: serviceType)
-            MPCBrowser.sharedBrowser = newBrowser
-            self.init(browser: newBrowser, session: session, myPeerId: myPeerID)
-        }
-    }
-
-    deinit {
-        if MPCBrowser.sharedBrowser === browser {
-            MPCBrowser.sharedBrowser = nil
-            SNMLogger.log("MPCBrowser deinit")
-        }
-    }
-
     func startBrowsing() {
         browser.startBrowsingForPeers()
         SNMLogger.log("start Browsing")
-
     }
-    
     func stopBrowsing() {
         browser.stopBrowsingForPeers()
         SNMLogger.log("stop Browsing")
     }
-
     func invite(peerID: MCPeerID) {
         browser.invitePeer(peerID, to: session, withContext: nil, timeout: 30)
         SNMLogger.log("invitePeer peerID")
     }
-    
     func invite(peerID: MCPeerID, tokenData: Data) {
         browser.invitePeer(peerID, to: session, withContext: tokenData, timeout: 30)
         SNMLogger.log("invitePeer tokenData")

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -8,22 +8,30 @@ import MultipeerConnectivity
 import os
 
 final class MPCBrowser {
-    let browser: MCNearbyServiceBrowser
+    var browser: MCNearbyServiceBrowser
     let session: MCSession
-    let myPeerId: MCPeerID
-    
+    var myPeerId: MCPeerID
+    let serviceType: String
+
     init(browser: MCNearbyServiceBrowser,
          session: MCSession,
-         myPeerId: MCPeerID)
+         myPeerId: MCPeerID,
+         serviceType: String)
     {
         self.browser = browser
         self.session = session
         self.myPeerId = myPeerId
+        self.serviceType = serviceType
     }
     convenience init(session: MCSession, myPeerID: MCPeerID, serviceType: String) {
         let newBrowser = MCNearbyServiceBrowser(peer: myPeerID,
                                                 serviceType: serviceType)
-        self.init(browser: newBrowser, session: session, myPeerId: myPeerID)
+        self.init(
+            browser: newBrowser,
+            session: session,
+            myPeerId: myPeerID,
+            serviceType: serviceType
+        )
     }
     
     func startBrowsing() {
@@ -41,5 +49,10 @@ final class MPCBrowser {
     func invite(peerID: MCPeerID, tokenData: Data) {
         browser.invitePeer(peerID, to: session, withContext: tokenData, timeout: 30)
         SNMLogger.log("invitePeer tokenData")
+    }
+    func setMyPeerID(peerID: MCPeerID) {
+        myPeerId = peerID
+        browser = MCNearbyServiceBrowser(peer: myPeerId,
+                                         serviceType: serviceType)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -50,5 +50,4 @@ final class MPCBrowser {
         browser.invitePeer(peerID, to: session, withContext: tokenData, timeout: 30)
         SNMLogger.log("invitePeer tokenData")
     }
-    }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -152,7 +152,7 @@ extension MPCManager {
         do {
             try self.session.send(data, toPeers: [connectedPeer], with: .reliable)
         } catch {
-            SNMLogger.error("DogProfileInfo 전송 실패 \(error.localizedDescription)")
+            SNMLogger.error("Fail to send data through mpcSession: \(error.localizedDescription)")
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -35,15 +35,13 @@ final class MPCManager: NSObject {
         self.advertiser.advertiser.delegate = self
         self.bind()
     }
-
-    func setMyPeerID(_ peerName: String) {
-        let peerID = MCPeerID(displayName: peerName)
-        advertiser.setMyPeerID(peerID: peerID)
-        browser.setMyPeerID(peerID: peerID)
-    }
-    convenience init(nickName: String) {
-        let yourName = nickName
-        let peerID = MCPeerID(displayName: yourName)
+    convenience init?(dataManager: DataLoadable) {
+        guard let dog = try? dataManager.loadData(
+            forKey: Environment.UserDefaultsKey.dogInfo,
+            type: UserInfo.self
+        ) else { return nil }
+        let myName: String = "\(dog.name)의 \(dog.nickname)"
+        let peerID = MCPeerID(displayName: myName)
         let serviceType = String.serviceName
         let session = MCSession(peer: peerID)
 

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -15,26 +15,19 @@ extension String {
 }
 
 final class MPCManager: NSObject {
-    let advertiser: MPCAdvertiser
-    let browser: MPCBrowser
+    var advertiser: MPCAdvertiser
+    var browser: MPCBrowser
     let session: MCSession
-    let mypeerID: MCPeerID
-    private let encoder: JSONEncoder
 
+    private var cancellables = Set<AnyCancellable>()
     var availablePeers = Set<MCPeerID>()
     var connectedPeerManager: ConnectedPeerManager
-    private var cancellables = Set<AnyCancellable>()
-    var receivedTokenPublisher = PassthroughSubject<Data, Never>()
-    var receivedDataPublisher = PassthroughSubject<DogProfileDTO, Never>()
-    var receivedViewTransitionPublisher = PassthroughSubject<String, Never>()
     var isAvailableToBeConnected = CurrentValueSubject<Bool, Never>(false)
 
-    init(advertiser: MPCAdvertiser, browser: MPCBrowser, session: MCSession, mypeerID: MCPeerID) {
+    init(advertiser: MPCAdvertiser, browser: MPCBrowser, session: MCSession) {
         self.advertiser = advertiser
         self.browser = browser
         self.session = session
-        self.mypeerID = mypeerID
-        encoder = JSONEncoder()
         connectedPeerManager = ConnectedPeerManager()
         super.init()
 
@@ -42,7 +35,12 @@ final class MPCManager: NSObject {
         self.advertiser.advertiser.delegate = self
         self.bind()
     }
-    
+
+    func setMyPeerID(_ peerName: String) {
+        let peerID = MCPeerID(displayName: peerName)
+        advertiser.setMyPeerID(peerID: peerID)
+        browser.setMyPeerID(peerID: peerID)
+    }
     convenience init(nickName: String) {
         let yourName = nickName
         let peerID = MCPeerID(displayName: yourName)
@@ -60,8 +58,7 @@ final class MPCManager: NSObject {
                 myPeerID: peerID,
                 serviceType: serviceType
             ),
-            session: session,
-            mypeerID: peerID
+            session: session
         )
     }
     deinit {

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -49,44 +49,26 @@ final class MPCManager: NSObject {
         let serviceType = String.serviceName
         let session = MCSession(peer: peerID)
 
-        self.init(advertiser: MPCAdvertiser(session: session,
-                                            myPeerID: peerID,
-                                            serviceType: serviceType),
-                  browser:  MPCBrowser(session: session,
-                                       myPeerID: peerID,
-                                       serviceType: serviceType),
-                  session: session,
-                  mypeerID: peerID)
+        self.init(
+            advertiser: MPCAdvertiser(
+                session: session,
+                myPeerID: peerID,
+                serviceType: serviceType
+            ),
+            browser: MPCBrowser(
+                session: session,
+                myPeerID: peerID,
+                serviceType: serviceType
+            ),
+            session: session,
+            mypeerID: peerID
+        )
     }
-    
     deinit {
         advertiser.stopAdvertising()
         browser.stopBrowsing()
     }
 
-    func sendToken(discoveryToken: Data) async {
-        guard let connectedPeer = await connectedPeerManager.connectedPeer else { return }
-        do {
-            let dataToSend = MPCProfileDropDTO(
-                token: discoveryToken,
-                profile: nil,
-                transitionMessage: nil
-            )
-            let encodedData = try encoder.encode(dataToSend)
-            try session.send(encodedData, toPeers: [connectedPeer], with: .reliable)
-        } catch {
-            SNMLogger.error("error sending \(error.localizedDescription)")
-        }
-    }
-    /// 연결된 한명의 피어에게만 데이터를 전송합니다.
-    func send(data: Data) async {
-        guard let connectedPeer = await connectedPeerManager.connectedPeer else { return }
-        do {
-            try self.session.send(data, toPeers: [connectedPeer], with: .reliable)
-        } catch {
-            SNMLogger.error("DogProfileInfo 전송 실패 \(error.localizedDescription)")
-        }
-    }
     private func bind() {
         isAvailableToBeConnected
             .sink { [weak self] isAvailable in
@@ -102,7 +84,6 @@ final class MPCManager: NSObject {
     }
 }
 
-
 extension MPCManager: MCNearbyServiceAdvertiserDelegate {
     func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
                     didNotStartAdvertisingPeer error: Error) {
@@ -116,7 +97,6 @@ extension MPCManager: MCNearbyServiceAdvertiserDelegate {
     {
         SNMLogger.info("Received invitation from \(peerID)")
         invitationHandler(true, session)
-        
     }
 }
 
@@ -134,17 +114,30 @@ extension MPCManager: MCNearbyServiceBrowserDelegate {
         guard !self.availablePeers.contains(peerID) else { return }
         self.availablePeers.insert(peerID)
 
-        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
-            if (self?.session.connectedPeers.contains(peerID) == false) {
-                self?.browser.invite(peerID: peerID)
-            }
-        }
+        self.browser.invite(peerID: peerID)
+//        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+//            if (self?.session.connectedPeers.contains(peerID) == false) {
+//                self?.browser.invite(peerID: peerID)
+//            }
+//        }
         SNMLogger.info("availablePeers: \(self.availablePeers)")
     }
 
     func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
         guard let index = availablePeers.firstIndex(of: peerID) else { return }
         self.availablePeers.remove(at: index)
+    }
+}
+
+extension MPCManager {
+    /// 연결된 한명의 피어에게만 데이터를 전송합니다.
+    func send(data: Data) async {
+        guard let connectedPeer = await connectedPeerManager.connectedPeer else { return }
+        do {
+            try self.session.send(data, toPeers: [connectedPeer], with: .reliable)
+        } catch {
+            SNMLogger.error("DogProfileInfo 전송 실패 \(error.localizedDescription)")
+        }
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -17,13 +17,14 @@ extension String {
 final class MPCManager: NSObject {
     var advertiser: MPCAdvertiser
     var browser: MPCBrowser
-    let session: MCSession
+    var session: MCSession
 
     private var cancellables = Set<AnyCancellable>()
     var availablePeers = Set<MCPeerID>()
     var connectedPeerManager: ConnectedPeerManager
     var isAvailableToBeConnected = CurrentValueSubject<Bool, Never>(false)
 
+    
     init(advertiser: MPCAdvertiser, browser: MPCBrowser, session: MCSession) {
         self.advertiser = advertiser
         self.browser = browser
@@ -60,10 +61,13 @@ final class MPCManager: NSObject {
         )
     }
     deinit {
+        browser.browser.delegate = nil
+        advertiser.advertiser.delegate = nil
         advertiser.stopAdvertising()
         browser.stopBrowsing()
+        session.disconnect()
+        SNMLogger.print("deinit MPCManager")
     }
-
     private func bind() {
         isAvailableToBeConnected
             .sink { [weak self] isAvailable in
@@ -71,8 +75,13 @@ final class MPCManager: NSObject {
                     self?.advertiser.startAdvertising()
                     self?.browser.startBrowsing()
                 } else {
+                    self?.session.disconnect()
+                    self?.session.delegate = nil
                     self?.advertiser.stopAdvertising()
                     self?.browser.stopBrowsing()
+                    Task {
+                        await self?.connectedPeerManager.disconnect()
+                    }
                 }
             }
             .store(in: &cancellables)
@@ -108,17 +117,24 @@ extension MPCManager: MCNearbyServiceBrowserDelegate {
         SNMLogger.info("ServiceBrowser found peer: \(peerID)")
         guard !self.availablePeers.contains(peerID) else { return }
         self.availablePeers.insert(peerID)
-
         self.browser.invite(peerID: peerID)
-//        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
-//            if (self?.session.connectedPeers.contains(peerID) == false) {
-//                self?.browser.invite(peerID: peerID)
-//            }
-//        }
+        Task { [weak self] in
+            try await Task.sleep(nanoseconds: 100_000_000)
+            if (self?.session.connectedPeers.contains(peerID) == false) {
+                self?.browser.invite(peerID: peerID)
+            }
+        }
         SNMLogger.info("availablePeers: \(self.availablePeers)")
     }
 
     func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        Task {
+            if let connectedPeer = await connectedPeerManager.connectedPeer,
+               connectedPeer == peerID
+            {
+                await connectedPeerManager.disconnect()
+            }
+        }
         guard let index = availablePeers.firstIndex(of: peerID) else { return }
         self.availablePeers.remove(at: index)
     }
@@ -127,7 +143,12 @@ extension MPCManager: MCNearbyServiceBrowserDelegate {
 extension MPCManager {
     /// 연결된 한명의 피어에게만 데이터를 전송합니다.
     func send(data: Data) async {
-        guard let connectedPeer = await connectedPeerManager.connectedPeer else { return }
+        guard let connectedPeer = await connectedPeerManager.connectedPeer,
+              availablePeers.contains(connectedPeer)
+        else {
+            await connectedPeerManager.disconnect()
+            return
+        }
         do {
             try self.session.send(data, toPeers: [connectedPeer], with: .reliable)
         } catch {

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -14,48 +14,37 @@ extension String {
     static var serviceName = "SniffMeet"
 }
 
-final class MPCManager {
+final class MPCManager: NSObject {
     let advertiser: MPCAdvertiser
     let browser: MPCBrowser
     let session: MCSession
     let mypeerID: MCPeerID
-    let encoder: JSONEncoder
+    private let encoder: JSONEncoder
+
+    var availablePeers = Set<MCPeerID>()
+    var connectedPeer: MCPeerID?
 
     private var cancellables = Set<AnyCancellable>()
     var receivedTokenPublisher = PassthroughSubject<Data, Never>()
     var receivedDataPublisher = PassthroughSubject<DogProfileDTO, Never>()
     var receivedViewTransitionPublisher = PassthroughSubject<String, Never>()
-    var isAvailableToBeConnected: Bool = false {
-        didSet {
-            if isAvailableToBeConnected {
-                advertiser.startAdvertising()
-                browser.startBrowsing()
-            } else {
-                advertiser.stopAdvertising()
-                browser.stopBrowsing()
-            }
+    var isAvailableToBeConnected = CurrentValueSubject<Bool, Never>(false)
 
-            advertiser.receivedInvite
-                .sink { [weak self] bool in
-                    SNMLogger.info("receivedInvite : \(bool)")
-                    if bool {
-                        self?.browser.stopBrowsing()
-                    }
-                }
-                .store(in: &cancellables)
-        }
-    }
-    
     init(advertiser: MPCAdvertiser, browser: MPCBrowser, session: MCSession, mypeerID: MCPeerID) {
         self.advertiser = advertiser
         self.browser = browser
         self.session = session
         self.mypeerID = mypeerID
         encoder = JSONEncoder()
+        super.init()
+
+        self.browser.browser.delegate = self
+        self.advertiser.advertiser.delegate = self
+        self.bind()
     }
     
-    convenience init() {
-        let yourName = String(UUID().uuidString.suffix(8))
+    convenience init(nickName: String) {
+        let yourName = nickName
         let peerID = MCPeerID(displayName: yourName)
         let serviceType = String.serviceName
         let session = MCSession(peer: peerID)
@@ -76,44 +65,91 @@ final class MPCManager {
     }
 
     func sendToken(discoveryToken: Data) {
-        guard !session.connectedPeers.isEmpty else { return }
-
+        guard let connectedPeer else { return }
         do {
-            let dataToSend = MPCProfileDropDTO(token: discoveryToken, profile: nil, transitionMessage: nil)
+            let dataToSend = MPCProfileDropDTO(
+                token: discoveryToken,
+                profile: nil,
+                transitionMessage: nil
+            )
             let encodedData = try encoder.encode(dataToSend)
-            SNMLogger.info("encodedToken is  \(encodedData)")
-            try session.send(encodedData, toPeers: session.connectedPeers, with: .reliable)
+            try session.send(encodedData, toPeers: [connectedPeer], with: .reliable)
         } catch {
             SNMLogger.error("error sending \(error.localizedDescription)")
         }
     }
-    
+    /// 연결된 한명의 피어에게만 데이터를 전송합니다.
     func send(data: Data) {
-        guard !session.connectedPeers.isEmpty else {
-            SNMLogger.log("no one is connected")
-            isAvailableToBeConnected = true
-            return
-        }
+        guard let connectedPeer else { return }
+
         do {
-            let decodedData = try JSONDecoder().decode(MPCProfileDropDTO.self, from: data)
-            if let flag = decodedData.transitionMessage {
-                SNMLogger.log("transitionMessage flag 전송 성공")
-            }
-            try self.session.send(data, toPeers: session.connectedPeers, with: .reliable)
+            try self.session.send(data, toPeers: [connectedPeer], with: .reliable)
         } catch {
             SNMLogger.error("DogProfileInfo 전송 실패 \(error.localizedDescription)")
         }
     }
-    func send(viewTransitionInfo: String) {
-        guard !session.connectedPeers.isEmpty else { return }
-
-        do {
-            let dataToSend = MPCProfileDropDTO(token: nil, profile: nil, transitionMessage: viewTransitionInfo)
-            let encodedData = try JSONEncoder().encode(dataToSend)
-            SNMLogger.info("encodedToken is  \(encodedData)")
-            try session.send(encodedData, toPeers: session.connectedPeers, with: .reliable)
-        } catch {
-            SNMLogger.error("error sending \(error.localizedDescription)")
-        }
+    private func bind() {
+        isAvailableToBeConnected
+            .sink { [weak self] isAvailable in
+                if isAvailable {
+                    self?.advertiser.startAdvertising()
+                    self?.browser.startBrowsing()
+                } else {
+                    self?.advertiser.stopAdvertising()
+                    self?.browser.stopBrowsing()
+                }
+            }
+            .store(in: &cancellables)
     }
+}
+
+
+extension MPCManager: MCNearbyServiceAdvertiserDelegate {
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
+                    didNotStartAdvertisingPeer error: Error) {
+        SNMLogger.info("Advertiser failed to start: \(error)")
+    }
+
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
+                    didReceiveInvitationFromPeer peerID: MCPeerID,
+                    withContext context: Data?,
+                    invitationHandler: @escaping (Bool, MCSession?) -> Void)
+    {
+        SNMLogger.info("Received invitation from \(peerID)")
+        invitationHandler(true, session)
+    }
+}
+
+extension MPCManager: MCNearbyServiceBrowserDelegate {
+    func browser(_ browser: MCNearbyServiceBrowser,
+                 foundPeer peerID: MCPeerID,
+                 withDiscoveryInfo info: [String : String]?)
+    {
+        if let info = info {
+            SNMLogger.info("Found peer with info: \(info)")
+        }
+
+        // info에 해당되는 peer에 대해서만 availablepeers에 넣을 수 있다
+        SNMLogger.info("ServiceBrowser found peer: \(peerID)")
+        guard !self.availablePeers.contains(peerID) else { return }
+        self.availablePeers.insert(peerID)
+
+        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+            if (self?.session.connectedPeers.contains(peerID) == false) {
+                self?.browser.invite(peerID: peerID)
+            }
+        }
+        SNMLogger.info("availablePeers: \(self.availablePeers)")
+    }
+
+
+    func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
+        guard let index = availablePeers.firstIndex(of: peerID) else { return }
+        self.availablePeers.remove(at: index)
+    }
+}
+
+// connected peer에 대해서만 동시성 문제 발생 예상
+actor ConnectedPeerManager {
+
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -22,8 +22,7 @@ final class MPCManager: NSObject {
     private let encoder: JSONEncoder
 
     var availablePeers = Set<MCPeerID>()
-    var connectedPeer: MCPeerID?
-
+    var connectedPeerManager: ConnectedPeerManager
     private var cancellables = Set<AnyCancellable>()
     var receivedTokenPublisher = PassthroughSubject<Data, Never>()
     var receivedDataPublisher = PassthroughSubject<DogProfileDTO, Never>()
@@ -36,6 +35,7 @@ final class MPCManager: NSObject {
         self.session = session
         self.mypeerID = mypeerID
         encoder = JSONEncoder()
+        connectedPeerManager = ConnectedPeerManager()
         super.init()
 
         self.browser.browser.delegate = self
@@ -64,8 +64,8 @@ final class MPCManager: NSObject {
         browser.stopBrowsing()
     }
 
-    func sendToken(discoveryToken: Data) {
-        guard let connectedPeer else { return }
+    func sendToken(discoveryToken: Data) async {
+        guard let connectedPeer = await connectedPeerManager.connectedPeer else { return }
         do {
             let dataToSend = MPCProfileDropDTO(
                 token: discoveryToken,
@@ -79,9 +79,8 @@ final class MPCManager: NSObject {
         }
     }
     /// 연결된 한명의 피어에게만 데이터를 전송합니다.
-    func send(data: Data) {
-        guard let connectedPeer else { return }
-
+    func send(data: Data) async {
+        guard let connectedPeer = await connectedPeerManager.connectedPeer else { return }
         do {
             try self.session.send(data, toPeers: [connectedPeer], with: .reliable)
         } catch {
@@ -117,6 +116,7 @@ extension MPCManager: MCNearbyServiceAdvertiserDelegate {
     {
         SNMLogger.info("Received invitation from \(peerID)")
         invitationHandler(true, session)
+        
     }
 }
 
@@ -142,7 +142,6 @@ extension MPCManager: MCNearbyServiceBrowserDelegate {
         SNMLogger.info("availablePeers: \(self.availablePeers)")
     }
 
-
     func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
         guard let index = availablePeers.firstIndex(of: peerID) else { return }
         self.availablePeers.remove(at: index)
@@ -151,5 +150,13 @@ extension MPCManager: MCNearbyServiceBrowserDelegate {
 
 // connected peer에 대해서만 동시성 문제 발생 예상
 actor ConnectedPeerManager {
-
+    var connectedPeer: MCPeerID?
+    
+    func connect(peer: MCPeerID) {
+        if connectedPeer != nil { return }
+        connectedPeer = peer
+    }
+    func disconnect() {
+        connectedPeer = nil
+    }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
@@ -8,36 +8,23 @@
 import Combine
 import NearbyInteraction
 
-final class NIManager: NSObject {
+final class NIManager {
     var niSession: NISession?
     private var cancellables = Set<AnyCancellable>()
-    var mpcManager: MPCManager
 
-    init(mpcManager: MPCManager) {
-        self.mpcManager = mpcManager
-        super.init()
-        setupNISession()
-    }
-
-    func setupNISession() {
+    init() {
         niSession = NISession()
     }
 
-    func sendDiscoveryToken() async {
+    func discoveryToken() -> Data? {
         guard let niSession = niSession, let discoveryToken = niSession.discoveryToken else {
             SNMLogger.log("Discovery token is not available.")
-            return
+            return nil
         }
-        do {
-            let tokenData = try NSKeyedArchiver.archivedData(
-                withRootObject: discoveryToken,
-                requiringSecureCoding: true
-            )
-            await mpcManager.sendToken(discoveryToken: tokenData)
-            SNMLogger.log("Discovery token sent to peer.")
-        } catch {
-            SNMLogger.error("Failed to encode discovery token: \(error)")
-        }
+        return try? NSKeyedArchiver.archivedData(
+            withRootObject: discoveryToken,
+            requiringSecureCoding: true
+        )
     }
 
     // discoveryToken 수신 처리
@@ -63,7 +50,5 @@ final class NIManager: NSObject {
 
     func endSession() {
         niSession?.invalidate()
-        mpcManager.session.disconnect()
-        mpcManager.isAvailableToBeConnected.send(false)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
@@ -62,10 +62,8 @@ final class NIManager: NSObject {
     }
 
     func endSession() {
-        SNMLogger.log("NI 세션 종료")
         niSession?.invalidate()
         mpcManager.session.disconnect()
-        mpcManager.isAvailableToBeConnected = false
-        SNMLogger.log("MPC 세션 종료")
+        mpcManager.isAvailableToBeConnected.send(false)
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
@@ -49,6 +49,7 @@ final class NIManager {
     }
 
     func endSession() {
+        niSession?.delegate = nil
         niSession?.invalidate()
     }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/NI/NIManager.swift
@@ -23,7 +23,7 @@ final class NIManager: NSObject {
         niSession = NISession()
     }
 
-    func sendDiscoveryToken() {
+    func sendDiscoveryToken() async {
         guard let niSession = niSession, let discoveryToken = niSession.discoveryToken else {
             SNMLogger.log("Discovery token is not available.")
             return
@@ -33,7 +33,7 @@ final class NIManager: NSObject {
                 withRootObject: discoveryToken,
                 requiringSecureCoding: true
             )
-            mpcManager.sendToken(discoveryToken: tokenData)
+            await mpcManager.sendToken(discoveryToken: tokenData)
             SNMLogger.log("Discovery token sent to peer.")
         } catch {
             SNMLogger.error("Failed to encode discovery token: \(error)")

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -87,9 +87,9 @@ final class MateListInteractor: MateListInteractable {
             .receive(on: RunLoop.main)
             .sink {[weak self] (profile) in
                 guard let profile else { return }
-                if self?.tryProfileDropUseCase.isTransistioned == false {
+                if self?.tryProfileDropUseCase.isTransitioned == false {
                     self?.presenter?.receiveProfileData(profile)
-                    self?.tryProfileDropUseCase.isTransistioned = true
+                    self?.tryProfileDropUseCase.isTransitioned = true
                 }
             }
             .store(in: &cancellables)
@@ -97,7 +97,7 @@ final class MateListInteractor: MateListInteractable {
     
     func tryProfileDrop() {
         // 정보 load
-        if tryProfileDropUseCase.isTransistioned {
+        if tryProfileDropUseCase.isTransitioned {
             guard let mpcManager = MPCManager(dataManager: LocalDataManager())
             else { return }
             let niManager = NIManager()

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -98,11 +98,11 @@ final class MateListInteractor: MateListInteractable {
     func tryProfileDrop() {
         // 정보 load
         if tryProfileDropUseCase.isTransistioned {
-            let mpcManager = MPCManager(nickName: Environment.LocalNetworkKey.defaultPeerName)
+            guard let mpcManager = MPCManager(dataManager: LocalDataManager())
+            else { return }
             let niManager = NIManager()
             tryProfileDropUseCase.reset(mpcManager: mpcManager, nimanager: niManager)
             quitProfileDropUseCase.reset(niManager: niManager)
-            tryProfileDropUseCase.isTransistioned = false
         }
         tryProfileDropUseCase.execute()
     }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -4,8 +4,10 @@
 //
 //  Created by Kelly Chui on 11/21/24.
 //
+
 import Combine
 import Foundation
+import MultipeerConnectivity
 
 protocol MateListInteractable: AnyObject {
     var presenter: (any MateListInteractorOutput)? { get set }
@@ -94,14 +96,13 @@ final class MateListInteractor: MateListInteractable {
     }
     
     func tryProfileDrop() {
+        // 정보 load
         if tryProfileDropUseCase.isTransistioned {
-            // FIXME: nickName 설정 필요 
-            let mpcManager = MPCManager(nickName: "")
-            let niManager = NIManager(mpcManager: mpcManager)
+            let mpcManager = MPCManager(nickName: Environment.LocalNetworkKey.defaultPeerName)
+            let niManager = NIManager()
             tryProfileDropUseCase.reset(mpcManager: mpcManager, nimanager: niManager)
             quitProfileDropUseCase.reset(niManager: niManager)
             tryProfileDropUseCase.isTransistioned = false
-
         }
         tryProfileDropUseCase.execute()
     }

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -95,7 +95,8 @@ final class MateListInteractor: MateListInteractable {
     
     func tryProfileDrop() {
         if tryProfileDropUseCase.isTransistioned {
-            let mpcManager = MPCManager()
+            // FIXME: nickName 설정 필요 
+            let mpcManager = MPCManager(nickName: "")
             let niManager = NIManager(mpcManager: mpcManager)
             tryProfileDropUseCase.reset(mpcManager: mpcManager, nimanager: niManager)
             quitProfileDropUseCase.reset(niManager: niManager)

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -57,12 +57,13 @@ extension MateListRouter: MateListBuildable {
             remoteDatabaseManager: SupabaseDatabaseManager.shared)
         let requestProfileImageUseCase: RequestProfileImageUseCase = RequestProfileImageUseCaseImpl(
             remoteImageManager: SupabaseStorageManager(
-            networkProvider: SNMNetworkProvider()),
+                networkProvider: SNMNetworkProvider()),
             cacheManager: CacheManager.shared
         )
 
-        // FIXME: nickName 설정하는 부분 변경 필요
-        let mpcManager = MPCManager(nickName: Environment.LocalNetworkKey.defaultPeerName)
+        guard let mpcManager = MPCManager(dataManager: LocalDataManager()) else {
+            return UIViewController()
+        }
         let niManager = NIManager()
         let tryProfileDropUseCase: TryProfileDropUseCase =
         TryProfileDropUseCaseImpl(

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -57,7 +57,8 @@ extension MateListRouter: MateListBuildable {
             remoteDatabaseManager: SupabaseDatabaseManager.shared)
         let requestProfileImageUseCase: RequestProfileImageUseCase = RequestProfileImageUseCaseImpl(
             remoteImageManager: SupabaseStorageManager(
-                networkProvider: SNMNetworkProvider()),
+                networkProvider: SNMNetworkProvider()
+            ),
             cacheManager: CacheManager.shared
         )
 

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -60,7 +60,9 @@ extension MateListRouter: MateListBuildable {
             networkProvider: SNMNetworkProvider()),
             cacheManager: CacheManager.shared
         )
-        let mpcManager = MPCManager()
+
+        // FIXME: nickName 설정하는 부분 변경 필요
+        let mpcManager = MPCManager(nickName: "")
         let niManager = NIManager(mpcManager: mpcManager)
         let tryProfileDropUseCase: TryProfileDropUseCase =
         TryProfileDropUseCaseImpl(

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -62,8 +62,8 @@ extension MateListRouter: MateListBuildable {
         )
 
         // FIXME: nickName 설정하는 부분 변경 필요
-        let mpcManager = MPCManager(nickName: "")
-        let niManager = NIManager(mpcManager: mpcManager)
+        let mpcManager = MPCManager(nickName: Environment.LocalNetworkKey.defaultPeerName)
+        let niManager = NIManager()
         let tryProfileDropUseCase: TryProfileDropUseCase =
         TryProfileDropUseCaseImpl(
             dataManager: LocalDataManager(),

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
@@ -29,6 +29,8 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
     var triedBefore: Bool = false
     let lock = NSLock()
 
+    var myPeerName: String?
+
     let dataManager: DataLoadable
     private var niManager: NIManager
     private var mpcManager: MPCManager
@@ -49,6 +51,10 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
         niManager.niSession?.delegate = self
         mpcManager.session.delegate = self
         encodeFlagData()
+        loadProfileData()
+        if let myPeerName {
+            mpcManager.setMyPeerID(myPeerName)
+        }
     }
     func reset(mpcManager: MPCManager, nimanager: NIManager) {
         isNIConnected.value = false
@@ -59,7 +65,9 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
         
         self.mpcManager = mpcManager
         self.niManager = nimanager
-        
+        if let myPeerName {
+            mpcManager.setMyPeerID(myPeerName)
+        }
         self.niManager.niSession?.delegate = self
         self.mpcManager.session.delegate = self
     }
@@ -77,7 +85,6 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
     
     func execute()  {
         triedBefore = true
-        loadProfileData()
         mpcManager.isAvailableToBeConnected.send(true)
     }
     
@@ -85,18 +92,25 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
         do {
             let dog = try dataManager.loadData(
                 forKey: Environment.UserDefaultsKey.dogInfo,
-                type: UserInfo.self)
+                type: UserInfo.self
+            )
             guard let userID = SessionManager.shared.session?.user?.userID else { return }
             let imageURL = try? dataManager.loadData(
                 forKey: Environment.UserDefaultsKey.profileImage,
-                type: String.self)
-            
-            let dogProfile = DogDTO( id: userID,
+                type: String.self
+            )
+            myPeerName = "\(dog.nickname)의 \(dog.name)"
+
+            let dogProfile = DogDTO(id: userID,
                 name: dog.name,
                 keywords: dog.keywords,
                 profileImage: imageURL
             )
-            let profileDropDTO = MPCProfileDropDTO(token: nil, profile: dogProfile, transitionMessage: nil)
+            let profileDropDTO = MPCProfileDropDTO(
+                token: nil,
+                profile: dogProfile,
+                transitionMessage: nil
+            )
             profileData = try encoder.encode(profileDropDTO)
         } catch {
             SNMLogger.error("loadData error : \(error)")
@@ -108,13 +122,6 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
     func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
         SNMLogger.info("peer \(peerID) didChangeState: \(state.rawValue)")
         switch state {
-        case .notConnected:
-            Task { @MainActor in
-                SNMLogger.log("notConnected to MPCSession: \(session.connectedPeers)")
-            }
-        case .connecting:
-            SNMLogger.log("connecting to MPCSession:")
-
         case .connected:
             Task {
                 SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers)")
@@ -127,39 +134,33 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
                         transitionMessage: nil)
                 )
                 await mpcManager.send(data: data)
-                niManager.mpcManager.isAvailableToBeConnected.send(false)
+                mpcManager.isAvailableToBeConnected.send(false)
             }
         default:
-            niManager.mpcManager.isAvailableToBeConnected.send(false)
+            mpcManager.isAvailableToBeConnected.send(false)
         }
     }
 
     // 수신
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-        Task {@MainActor [weak self] in
-            SNMLogger.info("didReceive bytes \(data.count) bytes")
+        Task { @MainActor [weak self] in
             do {
                 let receivedData = try self?.decoder.decode(MPCProfileDropDTO.self, from: data)
-                if let token = receivedData?.token { // 토큰
-                    guard let niConnected = self?.niManager.handleReceivedDiscoveryToken(token) else { return }
+                if let token = receivedData?.token,
+                   let niConnected = self?.niManager.handleReceivedDiscoveryToken(token) {
                     self?.isNIConnected.send(niConnected)
-                } else if let profile = receivedData?.profile { // 프로필 데이터
+                } else if let profile = receivedData?.profile,
+                          let receivedFlagData = self?.receivedFlagData { // 프로필 데이터
                     self?.profilePublisher.send(profile)
-                    guard let receivedFlagData = self?.receivedFlagData else { return }
                     await self?.mpcManager.send(data: receivedFlagData)
-                    SNMLogger.log("Receive profile data")
                 } else if let message = receivedData?.transitionMessage { // 수신 여부 플래그
-                    SNMLogger.log("flag message: \(message)")
-                    self?.lock.lock()
                     self?.transmissionFlag.insert(message)
-                    self?.lock.unlock()
                 }
             } catch {
                 SNMLogger.error("Failed to decode received data: \(error)")
             }
             if self?.transmissionFlag.contains(Context.peerReceived) == true && self?.isTransistioned == true {
                 self?.niManager.endSession()
-                SNMLogger.log("End all session")
             }
         }
     }
@@ -193,20 +194,19 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
     }
 }
 
+// MARK: - TryProfileDropUseCaseImpl+NISessionDelegate
+
 extension TryProfileDropUseCaseImpl: NISessionDelegate {
     func session(_ session: NISession, didUpdate nearbyObjects: [NINearbyObject])  {
         guard let nearbyObject = nearbyObjects.first else { return }
         let distance = nearbyObject.distance ?? 0
         Task { [weak self] in
-            if distance > Context.minDistance && distance < Context.maxDistance {
-                SNMLogger.log("조건 만족")
-
-                guard let profileData = self?.profileData else { return }
-                if self?.transmissionFlag.contains(Context.peerReceived) == false {
-                    await self?.mpcManager.send(data: profileData)
-                    SNMLogger.log("프로필 데이터 보낸다.")
-                    try await Task.sleep(nanoseconds: 2000000000)
-                }
+            guard (distance > Context.minDistance &&
+                    distance < Context.maxDistance),
+            let profileData = self?.profileData else { return }
+            if self?.transmissionFlag.contains(Context.peerReceived) == false {
+                await self?.mpcManager.send(data: profileData)
+                try await Task.sleep(nanoseconds: 2000000000)
             }
         }
     }

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
@@ -13,7 +13,7 @@ protocol TryProfileDropUseCase {
     var profilePublisher: CurrentValueSubject<DogDTO?, Never>  { get set }
     var isNIConnected: CurrentValueSubject<Bool, Never> { get set }
     var transmissionFlag: Set<String> { get set }
-    var isTransistioned: Bool { get set }
+    var isTransitioned: Bool { get set }
     var triedBefore: Bool { get set }
 
     func execute()
@@ -25,11 +25,8 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
     var profilePublisher: CurrentValueSubject<DogDTO?, Never> = CurrentValueSubject(nil)
     var isNIConnected: CurrentValueSubject<Bool, Never> = CurrentValueSubject(false)
     var transmissionFlag: Set<String>
-    var isTransistioned: Bool = false
+    var isTransitioned: Bool = false
     var triedBefore: Bool = false
-    let lock = NSLock()
-
-    var myPeerName: String?
 
     let dataManager: DataLoadable
     private var niManager: NIManager
@@ -38,7 +35,10 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
     let decoder: JSONDecoder
     private var profileData: Data? = nil
     private var receivedFlagData: Data? = nil
-    
+
+    private var recentInvalidMPCSession: MCSession?
+    private var recentInvalidNISession: NISession?
+
     init(dataManager: DataLoadable, niManager: NIManager, mpcManager: MPCManager) {
         self.dataManager = dataManager
         self.niManager = niManager
@@ -52,22 +52,19 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
         mpcManager.session.delegate = self
         encodeFlagData()
         loadProfileData()
-        if let myPeerName {
-            mpcManager.setMyPeerID(myPeerName)
-        }
     }
     func reset(mpcManager: MPCManager, nimanager: NIManager) {
         isNIConnected.value = false
         profilePublisher.value = nil
         transmissionFlag = []
-        isTransistioned = false
+        isTransitioned = false
         triedBefore = false
-        
+
+        recentInvalidMPCSession = self.mpcManager.session
+        recentInvalidNISession = self.niManager.niSession
+
         self.mpcManager = mpcManager
         self.niManager = nimanager
-        if let myPeerName {
-            mpcManager.setMyPeerID(myPeerName)
-        }
         self.niManager.niSession?.delegate = self
         self.mpcManager.session.delegate = self
     }
@@ -99,7 +96,6 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
                 forKey: Environment.UserDefaultsKey.profileImage,
                 type: String.self
             )
-            myPeerName = "\(dog.nickname)의 \(dog.name)"
 
             let dogProfile = DogDTO(id: userID,
                 name: dog.name,
@@ -120,30 +116,37 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
 // MARK: - MCSessionDelegate
 extension TryProfileDropUseCaseImpl: MCSessionDelegate {
     func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        guard session !== recentInvalidMPCSession else { return }
+
         SNMLogger.info("peer \(peerID) didChangeState: \(state.rawValue)")
-        switch state {
-        case .connected:
-            Task {
-                SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers)")
-                await mpcManager.connectedPeerManager.connect(peer: peerID)
-                guard let token = niManager.discoveryToken() else { return }
-                let data = try encoder.encode(
-                    MPCProfileDropDTO(
-                        token: token,
-                        profile: nil,
-                        transitionMessage: nil)
-                )
-                await mpcManager.send(data: data)
-                mpcManager.isAvailableToBeConnected.send(false)
+        Task {
+            switch state {
+            case .connected:
+                do {
+                    SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers) session \(session)")
+                    await mpcManager.connectedPeerManager.connect(peer: peerID)
+                    guard let token = niManager.discoveryToken() else { return }
+                    let data = try encoder.encode(
+                        MPCProfileDropDTO(
+                            token: token,
+                            profile: nil,
+                            transitionMessage: nil)
+                    )
+                    await mpcManager.send(data: data)
+                } catch {
+                    SNMLogger.error(error.localizedDescription)
+                }
+            default:
+                break
             }
-        default:
-            mpcManager.isAvailableToBeConnected.send(false)
         }
     }
 
     // 수신
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-        Task { @MainActor [weak self] in
+        guard session !== recentInvalidMPCSession else { return }
+
+        Task { [weak self] in
             do {
                 let receivedData = try self?.decoder.decode(MPCProfileDropDTO.self, from: data)
                 if let token = receivedData?.token,
@@ -159,8 +162,9 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
             } catch {
                 SNMLogger.error("Failed to decode received data: \(error)")
             }
-            if self?.transmissionFlag.contains(Context.peerReceived) == true && self?.isTransistioned == true {
+            if self?.transmissionFlag.contains(Context.peerReceived) == true && self?.isTransitioned == true {
                 self?.niManager.endSession()
+                self?.mpcManager.isAvailableToBeConnected.send(false)
             }
         }
     }
@@ -198,6 +202,8 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
 
 extension TryProfileDropUseCaseImpl: NISessionDelegate {
     func session(_ session: NISession, didUpdate nearbyObjects: [NINearbyObject])  {
+        guard session !== recentInvalidNISession else { return }
+
         guard let nearbyObject = nearbyObjects.first else { return }
         let distance = nearbyObject.distance ?? 0
         Task { [weak self] in
@@ -219,6 +225,9 @@ extension TryProfileDropUseCaseImpl: NISessionDelegate {
     }
     func session(_ session: NISession, didInvalidateWith error: Error) {
         SNMLogger.error("NearbyInteraction session invalidated: \(error)")
+    }
+    func sessionDidStartRunning(_ session: NISession) {
+        SNMLogger.print("NISession did start running: \(session)")
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
@@ -78,7 +78,7 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
     func execute()  {
         triedBefore = true
         loadProfileData()
-        mpcManager.isAvailableToBeConnected = true
+        mpcManager.isAvailableToBeConnected.send(true)
     }
     
     func loadProfileData() {
@@ -112,14 +112,17 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
             Task { @MainActor in
                 SNMLogger.log("notConnected to MPCSession: \(session.connectedPeers)")
             }
+        case .connecting:
+            SNMLogger.log("connecting to MPCSession:")
+
         case .connected:
             Task { @MainActor in
                 SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers)")
                 niManager.sendDiscoveryToken()
-                niManager.mpcManager.isAvailableToBeConnected = false
+                niManager.mpcManager.isAvailableToBeConnected.send(false)
             }
         default:
-            niManager.mpcManager.isAvailableToBeConnected = false
+            niManager.mpcManager.isAvailableToBeConnected.send(false)
         }
     }
 

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
@@ -116,9 +116,10 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
             SNMLogger.log("connecting to MPCSession:")
 
         case .connected:
-            Task { @MainActor in
+            Task {
                 SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers)")
-                niManager.sendDiscoveryToken()
+                await mpcManager.connectedPeerManager.connect(peer: peerID)
+                await niManager.sendDiscoveryToken()
                 niManager.mpcManager.isAvailableToBeConnected.send(false)
             }
         default:
@@ -138,7 +139,7 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
                 } else if let profile = receivedData?.profile { // 프로필 데이터
                     self?.profilePublisher.send(profile)
                     guard let receivedFlagData = self?.receivedFlagData else { return }
-                    self?.mpcManager.send(data: receivedFlagData)
+                    await self?.mpcManager.send(data: receivedFlagData)
                     SNMLogger.log("Receive profile data")
                 } else if let message = receivedData?.transitionMessage { // 수신 여부 플래그
                     SNMLogger.log("flag message: \(message)")
@@ -195,7 +196,7 @@ extension TryProfileDropUseCaseImpl: NISessionDelegate {
 
                 guard let profileData = self?.profileData else { return }
                 if self?.transmissionFlag.contains(Context.peerReceived) == false {
-                    self?.mpcManager.send(data: profileData)
+                    await self?.mpcManager.send(data: profileData)
                     SNMLogger.log("프로필 데이터 보낸다.")
                     try await Task.sleep(nanoseconds: 2000000000)
                 }

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
@@ -119,7 +119,14 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
             Task {
                 SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers)")
                 await mpcManager.connectedPeerManager.connect(peer: peerID)
-                await niManager.sendDiscoveryToken()
+                guard let token = niManager.discoveryToken() else { return }
+                let data = try encoder.encode(
+                    MPCProfileDropDTO(
+                        token: token,
+                        profile: nil,
+                        transitionMessage: nil)
+                )
+                await mpcManager.send(data: data)
                 niManager.mpcManager.isAvailableToBeConnected.send(false)
             }
         default:

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
@@ -117,11 +117,11 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
 extension TryProfileDropUseCaseImpl: MCSessionDelegate {
     func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
         guard session !== recentInvalidMPCSession else { return }
-
+        
         SNMLogger.info("peer \(peerID) didChangeState: \(state.rawValue)")
-        Task {
-            switch state {
-            case .connected:
+        switch state {
+        case .connected:
+            Task {
                 do {
                     SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers) session \(session)")
                     await mpcManager.connectedPeerManager.connect(peer: peerID)
@@ -136,9 +136,9 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
                 } catch {
                     SNMLogger.error(error.localizedDescription)
                 }
-            default:
-                break
             }
+        default:
+            break
         }
     }
 


### PR DESCRIPTION
### 🔖  Issue Number

close #1

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  MPC 연결을 최대 1명과 연결할 수 있도록 제한 
- [x] 기존 Advertiser, Broswer, Manager 코드 컨벤션에 맞게 수정 및 중복되는 코드 제거 
- [x] peeID를 "[닉네임]의 강아지 이름"으로 적용
- [x] NIManager, MPCManager 결합도 개선
        이제는 NIManager가 MPCManager를 알고 있지 않습니다. 

### 특이사항 
1. MPC 연결을 최대 1명과 연결할 수 있도록 Actor를 사용하여 제한하였습니다. 
```swift
// MPCManager.swift
actor ConnectedPeerManager {

    var connectedPeer: MCPeerID?

    func connect(peer: MCPeerID) {
        if connectedPeer != nil { return }
        connectedPeer = peer
    }
    func disconnect() {
        connectedPeer = nil
    }
}
```