### PR TITLE
[test] 동시성 환경에서 피어 연결 테스트 

### DIFF
--- a/SniffMeet/SNMSceneTests/LocalNetwork/ConnectedPeerManagerSpy.swift
+++ b/SniffMeet/SNMSceneTests/LocalNetwork/ConnectedPeerManagerSpy.swift
@@ -7,7 +7,7 @@
 
 import MultipeerConnectivity
 
-actor ConnectedPeerManagerSpy: @preconcurrency ConnectedPeerManagable {
+actor ConnectedPeerManagerSpy: ConnectedPeerManagable {
     var previousConnectedPeer: MCPeerID?
     var connectedPeer: MCPeerID?
     var connectedPeerCount: Int = 0

--- a/SniffMeet/SNMSceneTests/LocalNetwork/ConnectedPeerManagerSpy.swift
+++ b/SniffMeet/SNMSceneTests/LocalNetwork/ConnectedPeerManagerSpy.swift
@@ -1,0 +1,28 @@
+//
+//  ConnectedPeerManagerSpy.swift
+//  SniffMeet
+//
+//  Created by sole on 2/6/25.
+//
+
+import MultipeerConnectivity
+
+actor ConnectedPeerManagerSpy: @preconcurrency ConnectedPeerManagable {
+    var previousConnectedPeer: MCPeerID?
+    var connectedPeer: MCPeerID?
+    var connectedPeerCount: Int = 0
+    var connectionTrialCount: Int = 0
+
+    func connect(peer: MCPeerID) async {
+        connectionTrialCount += 1
+        guard connectedPeer == nil else { return }
+        connectedPeerCount += 1
+        connectedPeer = peer
+    }
+    func disconnect() async {
+        if connectedPeer != nil {
+            previousConnectedPeer = connectedPeer
+        }
+        connectedPeer = nil
+    }
+}

--- a/SniffMeet/SNMSceneTests/LocalNetwork/MPCSessionConcurrencyTest.swift
+++ b/SniffMeet/SNMSceneTests/LocalNetwork/MPCSessionConcurrencyTest.swift
@@ -12,10 +12,12 @@ final class MPCSessionConcurrencyTest: XCTestCase {
     private var sessionMock: MockMPCSession!
     private var sut: MPCManager!
     private var session: MCSession!
+    private var connectedPeerManagerSpy: ConnectedPeerManagerSpy!
     private var sessionPeerID: String = "session"
 
     override func setUp() {
         session = MCSession(peer: MCPeerID(displayName: sessionPeerID))
+        connectedPeerManagerSpy = ConnectedPeerManagerSpy()
         sut = MPCManager(
             advertiser:
                 MPCAdvertiser(
@@ -29,20 +31,20 @@ final class MPCSessionConcurrencyTest: XCTestCase {
                     myPeerID: MCPeerID(displayName: "test2"),
                     serviceType: "SniffMeet"
                 ),
-            session: session
+            session: session,
+            connectedPeerManager: connectedPeerManagerSpy
         )
         
         sessionMock = MockMPCSession(mpcManager: sut)
         session.delegate = sessionMock
     }
-
     override func tearDown() {
         session = nil
         sut = nil
         sessionMock = nil
     }
 
-    func test_mockSessionDelegate메서드호출할때_MPCManager가_피어정보를_알맞게_저장하는가() async {
+    func test_mockSessionDelegate_메서드_호출할때_MPCManager가_피어_정보를_알맞게_저장되어야_한다() async {
         // Arrange
         let peerName = "테스트 피어"
         // Act
@@ -61,12 +63,80 @@ final class MPCSessionConcurrencyTest: XCTestCase {
             XCTFail("connect된 peer가 없다. ")
         }
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+    func test_peer가_동시에_세션에_접근할_때_connectedPeer는_하나만_연결되어야_한다() async throws {
+        // Arrange
+        let peerName = "테스트 피어"
+        // Act
+        await withTaskGroup(of: Void.self) { [weak self] group in
+            guard let self else {
+                XCTFail("self 바인딩 실패 ")
+                return
+            }
+            for _ in 0..<1000 {
+                group.addTask {
+                    self.sessionMock.session(self.session, peer: MCPeerID(displayName: peerName), didChange: .connected)
+                }
+            }
         }
+        // Assert
+        try await Task.sleep(nanoseconds: 1000000000)
+        let connectedPeerCount = await connectedPeerManagerSpy.connectedPeerCount
+        let connectionTrialCount = await connectedPeerManagerSpy.connectionTrialCount
+        XCTAssertEqual(1, connectedPeerCount)
+        XCTAssertEqual(1000, connectionTrialCount)
     }
+    func test_connectedManager는_disconnect되면_새로운_peer를_연결할_수있다() async throws {
+        // Arrange
+        let peer = MCPeerID(displayName: "테스트1")
+        let otherPeer = MCPeerID(displayName: "테스트2")
 
+        // Act
+        sessionMock.session(session, peer: peer, didChange: .connected)
+        sessionMock.session(session, peer: peer, didChange: .notConnected)
+        sessionMock.session(session, peer: otherPeer, didChange: .connected)
+
+        // Assert
+        try await Task.sleep(nanoseconds: 1000000000)
+        let previousConnectedPeer = await connectedPeerManagerSpy.previousConnectedPeer
+        let connectedPeer = await connectedPeerManagerSpy.connectedPeer
+        XCTAssertEqual(peer, previousConnectedPeer)
+        XCTAssertEqual(otherPeer, connectedPeer)
+    }
+    func test_peer가_동시에_세션에_접근할때_disconnect된_시점에_새로운_peer를_연결할_수있다() async throws {
+        // Arrange
+        let peerName = "테스트 피어"
+        let firstConnectedPeer = MCPeerID(displayName: peerName)
+        sessionMock.session(self.session, peer: firstConnectedPeer, didChange: .connected)
+
+        // Act
+        await withTaskGroup(of: Void.self) { [weak self] group in
+            guard let self else {
+                XCTFail("self 바인딩 실패")
+                return
+            }
+            for _ in 0..<500 {
+                group.addTask {
+                    self.sessionMock.session(self.session, peer: MCPeerID(displayName: peerName), didChange: .connected)
+                }
+            }
+            group.addTask {
+                self.sessionMock.session(self.session, peer: MCPeerID(displayName: peerName), didChange: .notConnected)
+            }
+            for _ in 0..<500 {
+                group.addTask {
+                    self.sessionMock.session(self.session, peer: MCPeerID(displayName: peerName), didChange: .connected)
+                }
+            }
+        }
+        // Assert
+        try await Task.sleep(nanoseconds: 1000000000)
+        let connectedPeerCount = await connectedPeerManagerSpy.connectedPeerCount
+        let connectedTrialCount = await connectedPeerManagerSpy.connectionTrialCount
+        let connectedPeer = await connectedPeerManagerSpy.connectedPeer
+        let previousConnectedPeer = await connectedPeerManagerSpy.previousConnectedPeer
+        XCTAssertEqual(2, connectedPeerCount)
+        XCTAssertEqual(1001, connectedTrialCount)
+        XCTAssertEqual(previousConnectedPeer, firstConnectedPeer)
+        XCTAssertNotEqual(previousConnectedPeer, connectedPeer)
+    }
 }

--- a/SniffMeet/SNMSceneTests/LocalNetwork/MPCSessionConcurrencyTest.swift
+++ b/SniffMeet/SNMSceneTests/LocalNetwork/MPCSessionConcurrencyTest.swift
@@ -1,0 +1,72 @@
+//
+//  MPCSessionConcurrencyTest.swift
+//  SNMSceneTests
+//
+//  Created by 윤지성 on 2/6/25.
+//
+
+import XCTest
+import MultipeerConnectivity
+
+final class MPCSessionConcurrencyTest: XCTestCase {
+    private var sessionMock: MockMPCSession!
+    private var sut: MPCManager!
+    private var session: MCSession!
+    private var sessionPeerID: String = "session"
+
+    override func setUp() {
+        session = MCSession(peer: MCPeerID(displayName: sessionPeerID))
+        sut = MPCManager(
+            advertiser:
+                MPCAdvertiser(
+                    session: session,
+                    myPeerID: MCPeerID(displayName: "test1"),
+                    serviceType: "SniffMeet"
+                ),
+            browser:
+                MPCBrowser(
+                    session: session,
+                    myPeerID: MCPeerID(displayName: "test2"),
+                    serviceType: "SniffMeet"
+                ),
+            session: session
+        )
+        
+        sessionMock = MockMPCSession(mpcManager: sut)
+        session.delegate = sessionMock
+    }
+
+    override func tearDown() {
+        session = nil
+        sut = nil
+        sessionMock = nil
+    }
+
+    func test_mockSessionDelegate메서드호출할때_MPCManager가_피어정보를_알맞게_저장하는가() async {
+        // Arrange
+        let peerName = "테스트 피어"
+        // Act
+        sessionMock.session(session, peer: MCPeerID(displayName: peerName), didChange: .connected)
+        
+        // Assert
+        do {
+            try await Task.sleep(nanoseconds: 1000000000)
+        } catch {
+            XCTFail("connect된 peer가 없다. ")
+        }
+        let peerID = await sut.connectedPeerManager.connectedPeer
+        if let peerID {
+            XCTAssertEqual(peerID.displayName, peerName, "connected 상태 성공적" )
+        } else {
+            XCTFail("connect된 peer가 없다. ")
+        }
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/SniffMeet/SNMSceneTests/LocalNetwork/MockMPCSession.swift
+++ b/SniffMeet/SNMSceneTests/LocalNetwork/MockMPCSession.swift
@@ -34,6 +34,9 @@ final class MockMPCSession: NSObject, MCSessionDelegate {
             connectedState = .connecting
         case .notConnected:
             connectedState = .notConnected
+            Task {
+                await mpcManager.connectedPeerManager.disconnect()
+            }
         @unknown default:
             break
         }

--- a/SniffMeet/SNMSceneTests/LocalNetwork/MockMPCSession.swift
+++ b/SniffMeet/SNMSceneTests/LocalNetwork/MockMPCSession.swift
@@ -1,0 +1,73 @@
+//
+//  MockMPCSession.swift
+//  SniffMeet
+//
+//  Created by 윤지성 on 2/6/25.
+//
+import MultipeerConnectivity
+
+final class MockMPCSession: NSObject, MCSessionDelegate {
+    var connectedState: ConnectedState
+    var mpcManager: MPCManager
+    
+    init(
+        connectedState: ConnectedState = .notConnected,
+         mpcManager: MPCManager
+    ) {
+        self.connectedState = connectedState
+        self.mpcManager = mpcManager
+    }
+    
+    enum ConnectedState {
+        case connecting
+        case connected
+        case notConnected
+    }
+    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
+        switch state {
+        case .connected:
+            connectedState = .connected
+            Task {
+                await mpcManager.connectedPeerManager.connect(peer: peerID)
+            }
+        case .connecting:
+            connectedState = .connecting
+        case .notConnected:
+            connectedState = .notConnected
+        @unknown default:
+            break
+        }
+    }
+    
+    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        print("didReceive method call")
+    }
+    
+    func session(
+        _ session: MCSession,
+        didReceive stream: InputStream,
+        withName streamName: String,
+        fromPeer peerID: MCPeerID
+    ) {
+        print("didReceive stream: InputStream call")
+    }
+
+    func session(
+        _ session: MCSession,
+        didStartReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        with progress: Progress
+    ) {
+        print("didStartReceivingResourceWithName method call")
+    }
+
+    func session(
+        _ session: MCSession,
+        didFinishReceivingResourceWithName resourceName: String,
+        fromPeer peerID: MCPeerID,
+        at localURL: URL?,
+        withError error: (any Error)?
+    ) {
+        print("didFinishReceivingResourceWithName method call")
+    }
+}

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		320047DE2CFE9E0400D08B6D /* Extension + UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */; };
 		3200480C2CFF0FB400D08B6D /* ProfileDropAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */; };
 		320522BE2D0181A800F1677C /* ImageCacheable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320522BD2D0181A700F1677C /* ImageCacheable.swift */; };
+		32081A6A2D547F9F00D19235 /* MPCSessionConcurrencyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32081A692D547F9F00D19235 /* MPCSessionConcurrencyTest.swift */; };
+		32081A6C2D547FB700D19235 /* MockMPCSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32081A6B2D547FAB00D19235 /* MockMPCSession.swift */; };
 		32192B272D41E8FD00C876BA /* ImageSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24B1F2E2D3C33500012B860 /* ImageSampler.swift */; };
 		32192B282D41E91200C876BA /* TaskSerialQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD01D8F62D40AC8000AD4940 /* TaskSerialQueue.swift */; };
 		32192B292D41EAF600C876BA /* CGImageCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24B1F312D3C33660012B860 /* CGImageCoder.swift */; };
@@ -528,6 +530,8 @@
 		320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension + UIApplication.swift"; sourceTree = "<group>"; };
 		3200480B2CFF0FA600D08B6D /* ProfileDropAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDropAnimation.swift; sourceTree = "<group>"; };
 		320522BD2D0181A700F1677C /* ImageCacheable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheable.swift; sourceTree = "<group>"; };
+		32081A692D547F9F00D19235 /* MPCSessionConcurrencyTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPCSessionConcurrencyTest.swift; sourceTree = "<group>"; };
+		32081A6B2D547FAB00D19235 /* MockMPCSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMPCSession.swift; sourceTree = "<group>"; };
 		3284D34D2D2F9417000ABC04 /* DataStoragable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoragable.swift; sourceTree = "<group>"; };
 		32A7563B2D00397D00965F0A /* CacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 		32BD48282D3FEC9D0078DA9C /* SNMSceneTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNMSceneTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -914,9 +918,19 @@
 			path = PushNotification;
 			sourceTree = "<group>";
 		};
+		32081A662D547F4F00D19235 /* LocalNetwork */ = {
+			isa = PBXGroup;
+			children = (
+				32081A6B2D547FAB00D19235 /* MockMPCSession.swift */,
+				32081A692D547F9F00D19235 /* MPCSessionConcurrencyTest.swift */,
+			);
+			path = LocalNetwork;
+			sourceTree = "<group>";
+		};
 		32BD48322D3FECAE0078DA9C /* SNMSceneTests */ = {
 			isa = PBXGroup;
 			children = (
+				32081A662D547F4F00D19235 /* LocalNetwork */,
 				32BD48352D3FECFD0078DA9C /* MateListScene */,
 			);
 			path = SNMSceneTests;
@@ -2286,6 +2300,7 @@
 				32BD48432D3FF02C0078DA9C /* WalkLog.swift in Sources */,
 				32BD48442D3FF02C0078DA9C /* WalkNoti.swift in Sources */,
 				32BD48452D3FF02C0078DA9C /* Mate.swift in Sources */,
+				32081A6A2D547F9F00D19235 /* MPCSessionConcurrencyTest.swift in Sources */,
 				32BD48462D3FF02C0078DA9C /* UserInfo.swift in Sources */,
 				32BD48472D3FF02C0078DA9C /* Keyword.swift in Sources */,
 				32BD48482D3FF02C0078DA9C /* Size.swift in Sources */,
@@ -2414,6 +2429,7 @@
 				32BD48C62D3FF02C0078DA9C /* WalkLogPageViewController.swift in Sources */,
 				32BD48C72D3FF02C0078DA9C /* AddMateButton.swift in Sources */,
 				32BD48C82D3FF02C0078DA9C /* MateListViewController.swift in Sources */,
+				32081A6C2D547FB700D19235 /* MockMPCSession.swift in Sources */,
 				32BD48C92D3FF02C0078DA9C /* MateListInteractor.swift in Sources */,
 				32BD48CA2D3FF02C0078DA9C /* MateListPresenter.swift in Sources */,
 				32BD48CB2D3FF02C0078DA9C /* MateListRouter.swift in Sources */,

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -387,6 +387,9 @@
 		FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */; };
 		FD3A03422CD8CF460047B7ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
 		FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */; };
+		FD4855222D548F8200C66429 /* ConnectedPeerManagerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4855212D548F7A00C66429 /* ConnectedPeerManagerSpy.swift */; };
+		FD4855242D54996800C66429 /* ConnectedPeerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4855232D54996100C66429 /* ConnectedPeerManager.swift */; };
+		FD4855252D54996800C66429 /* ConnectedPeerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD4855232D54996100C66429 /* ConnectedPeerManager.swift */; };
 		FD5134172CEB738D002E76F3 /* UIControl + Publisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5134162CEB7388002E76F3 /* UIControl + Publisher.swift */; };
 		FD5134192CEB7ADE002E76F3 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5134182CEB7AD9002E76F3 /* HomeRouter.swift */; };
 		FD51341B2CEB7AE8002E76F3 /* HomePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD51341A2CEB7AE3002E76F3 /* HomePresenter.swift */; };
@@ -641,6 +644,8 @@
 		FD3A033B2CD8CF460047B7ED /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		FD3E57352D35210D003F3E01 /* SupabaseTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SupabaseTestPlan.xctestplan; sourceTree = "<group>"; };
+		FD4855212D548F7A00C66429 /* ConnectedPeerManagerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedPeerManagerSpy.swift; sourceTree = "<group>"; };
+		FD4855232D54996100C66429 /* ConnectedPeerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectedPeerManager.swift; sourceTree = "<group>"; };
 		FD5134162CEB7388002E76F3 /* UIControl + Publisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl + Publisher.swift"; sourceTree = "<group>"; };
 		FD5134182CEB7AD9002E76F3 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
 		FD51341A2CEB7AE3002E76F3 /* HomePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePresenter.swift; sourceTree = "<group>"; };
@@ -763,6 +768,7 @@
 		320044182CE48A1900D08B6D /* MPC */ = {
 			isa = PBXGroup;
 			children = (
+				FD4855232D54996100C66429 /* ConnectedPeerManager.swift */,
 				3200441D2CE48D1F00D08B6D /* MPCManager.swift */,
 				3200441B2CE48C5600D08B6D /* MPCAdvertiser.swift */,
 				320044192CE48A3100D08B6D /* MPCBroswer.swift */,
@@ -921,6 +927,7 @@
 		32081A662D547F4F00D19235 /* LocalNetwork */ = {
 			isa = PBXGroup;
 			children = (
+				FD4855212D548F7A00C66429 /* ConnectedPeerManagerSpy.swift */,
 				32081A6B2D547FAB00D19235 /* MockMPCSession.swift */,
 				32081A692D547F9F00D19235 /* MPCSessionConcurrencyTest.swift */,
 			);
@@ -2359,6 +2366,7 @@
 				32BD487C2D3FF02C0078DA9C /* AnyDecodable.swift in Sources */,
 				32BD487D2D3FF02C0078DA9C /* Extension + Date.swift in Sources */,
 				32BD487E2D3FF02C0078DA9C /* UIControl + Publisher.swift in Sources */,
+				FD4855222D548F8200C66429 /* ConnectedPeerManagerSpy.swift in Sources */,
 				32BD487F2D3FF02C0078DA9C /* Extension + Keyboard.swift in Sources */,
 				32BD48802D3FF02C0078DA9C /* Extension + UIView.swift in Sources */,
 				32BD48812D3FF02C0078DA9C /* Extension + Navigation.swift in Sources */,
@@ -2429,6 +2437,7 @@
 				32BD48C62D3FF02C0078DA9C /* WalkLogPageViewController.swift in Sources */,
 				32BD48C72D3FF02C0078DA9C /* AddMateButton.swift in Sources */,
 				32BD48C82D3FF02C0078DA9C /* MateListViewController.swift in Sources */,
+				FD4855252D54996800C66429 /* ConnectedPeerManager.swift in Sources */,
 				32081A6C2D547FB700D19235 /* MockMPCSession.swift in Sources */,
 				32BD48C92D3FF02C0078DA9C /* MateListInteractor.swift in Sources */,
 				32BD48CA2D3FF02C0078DA9C /* MateListPresenter.swift in Sources */,
@@ -2565,6 +2574,7 @@
 				320044712CEB45E000D08B6D /* RequestWalkPresenter.swift in Sources */,
 				995D94262CE32ECE005A47BF /* Extension + Keyboard.swift in Sources */,
 				FD9468D42CFD590700417DC1 /* ProfileEditViewController.swift in Sources */,
+				FD4855242D54996800C66429 /* ConnectedPeerManager.swift in Sources */,
 				FD9468D52CFD590700417DC1 /* ProfileEditPresenter.swift in Sources */,
 				FD9468D62CFD590700417DC1 /* ProfileEditInteractor.swift in Sources */,
 				FD9468D72CFD590700417DC1 /* ProfileEditRoutable.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/ConnectedPeerManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/ConnectedPeerManager.swift
@@ -1,0 +1,26 @@
+//
+//  ConnectedPeerManager.swift
+//  SniffMeet
+//
+//  Created by sole on 2/6/25.
+//
+
+import MultipeerConnectivity
+
+protocol ConnectedPeerManagable {
+    var connectedPeer: MCPeerID? { get }
+    func connect(peer: MCPeerID) async
+    func disconnect() async
+}
+
+actor ConnectedPeerManager: @preconcurrency ConnectedPeerManagable {
+    var connectedPeer: MCPeerID?
+
+    func connect(peer: MCPeerID) {
+        if connectedPeer != nil { return }
+        connectedPeer = peer
+    }
+    func disconnect() {
+        connectedPeer = nil
+    }
+}

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/ConnectedPeerManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/ConnectedPeerManager.swift
@@ -7,13 +7,13 @@
 
 import MultipeerConnectivity
 
-protocol ConnectedPeerManagable {
+protocol ConnectedPeerManagable: Actor {
     var connectedPeer: MCPeerID? { get }
     func connect(peer: MCPeerID) async
     func disconnect() async
 }
 
-actor ConnectedPeerManager: @preconcurrency ConnectedPeerManagable {
+actor ConnectedPeerManager: ConnectedPeerManagable {
     var connectedPeer: MCPeerID?
 
     func connect(peer: MCPeerID) {

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCAdvertiser.swift
@@ -36,6 +36,7 @@ final class MPCAdvertiser {
         )
         SNMLogger.log("Created new MCNearbyServiceAdvertiser instance")
     }
+    
     func startAdvertising() {
         advertiser.startAdvertisingPeer()
         SNMLogger.log("start advertising")

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCBroswer.swift
@@ -46,8 +46,4 @@ final class MPCBrowser {
         browser.invitePeer(peerID, to: session, withContext: nil, timeout: 30)
         SNMLogger.log("invitePeer peerID")
     }
-    func invite(peerID: MCPeerID, tokenData: Data) {
-        browser.invitePeer(peerID, to: session, withContext: tokenData, timeout: 30)
-        SNMLogger.log("invitePeer tokenData")
-    }
 }

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -10,7 +10,7 @@ import MultipeerConnectivity
 import NearbyInteraction
 import os
 
-extension String {
+fileprivate extension String {
     static var serviceName = "SniffMeet"
 }
 
@@ -23,7 +23,6 @@ final class MPCManager: NSObject {
     var availablePeers = Set<MCPeerID>()
     var connectedPeerManager: ConnectedPeerManager
     var isAvailableToBeConnected = CurrentValueSubject<Bool, Never>(false)
-
     
     init(advertiser: MPCAdvertiser, browser: MPCBrowser, session: MCSession) {
         self.advertiser = advertiser

--- a/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/LocalNetwork/MPC/MPCManager.swift
@@ -21,14 +21,19 @@ final class MPCManager: NSObject {
 
     private var cancellables = Set<AnyCancellable>()
     var availablePeers = Set<MCPeerID>()
-    var connectedPeerManager: ConnectedPeerManager
+    var connectedPeerManager: ConnectedPeerManagable
     var isAvailableToBeConnected = CurrentValueSubject<Bool, Never>(false)
     
-    init(advertiser: MPCAdvertiser, browser: MPCBrowser, session: MCSession) {
+    init(
+        advertiser: MPCAdvertiser,
+        browser: MPCBrowser,
+        session: MCSession,
+        connectedPeerManager: ConnectedPeerManagable = ConnectedPeerManager()
+    ) {
         self.advertiser = advertiser
         self.browser = browser
         self.session = session
-        connectedPeerManager = ConnectedPeerManager()
+        self.connectedPeerManager = connectedPeerManager
         super.init()
 
         self.browser.browser.delegate = self
@@ -153,18 +158,5 @@ extension MPCManager {
         } catch {
             SNMLogger.error("Fail to send data through mpcSession: \(error.localizedDescription)")
         }
-    }
-}
-
-// connected peer에 대해서만 동시성 문제 발생 예상
-actor ConnectedPeerManager {
-    var connectedPeer: MCPeerID?
-    
-    func connect(peer: MCPeerID) {
-        if connectedPeer != nil { return }
-        connectedPeer = peer
-    }
-    func disconnect() {
-        connectedPeer = nil
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TryProfileDropUseCase.swift
@@ -53,6 +53,7 @@ final class TryProfileDropUseCaseImpl: NSObject, TryProfileDropUseCase {
         encodeFlagData()
         loadProfileData()
     }
+    
     func reset(mpcManager: MPCManager, nimanager: NIManager) {
         isNIConnected.value = false
         profilePublisher.value = nil
@@ -162,7 +163,8 @@ extension TryProfileDropUseCaseImpl: MCSessionDelegate {
             } catch {
                 SNMLogger.error("Failed to decode received data: \(error)")
             }
-            if self?.transmissionFlag.contains(Context.peerReceived) == true && self?.isTransitioned == true {
+            if self?.transmissionFlag.contains(Context.peerReceived) == true
+                && self?.isTransitioned == true {
                 self?.niManager.endSession()
                 self?.mpcManager.isAvailableToBeConnected.send(false)
             }


### PR DESCRIPTION
### 🔖  Issue Number

close #6 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  MCSessionDelegate를 채택하는 Mock 객체, 연결된 peer를 관리하는 PeerConnectionManager Spy 객체 구현
- [x] Mock, Spy를 이용하여 동시성 환경에서 테스트 


### 테스트 과정 
MPCManager가 동시성 환경에서 올바르게 동작하는지 확인하기 위해서 유사하게 환경을 만드는게 필요했습니다. 
이와 유사하게 환경을 만들기 위하여 MCSessionDelegate 프로토콜을 채택하는 Mock 객체를 구현하고 peer 간의 연결 동작이 일어날 때 호출되는 메서드를 직접 호출하여 유사하게 동작할 수 있도록 제어했습니다. 

그리고 이런 동시성 환경에서 올바르게 동작되는지 connectedPeerManagerSpy를 만들어 MPCManager에 주입하여 결과를 간접적으로 확인할 수 있었습니다. 
 실제 코드 구조  |  테스트 구조
-- | --
<img width="612" alt="image" src="https://github.com/user-attachments/assets/d0d61ab5-e765-4afd-b16b-ac2e3b143158" /> |  <img width="594" alt="22" src="https://github.com/user-attachments/assets/659fb28d-1078-4009-bef2-4623527a824e" />


테스트 과정에 관련해서 더 자세하게 알고싶으시다면 아래 링크 참고해주시면 됩니다. 
[Peer가 동시적으로 접근하지 못하게 했어! 근데 어떻게 확인할 수 있을까? ](https://check-it.notion.site/Peer-5bafce33ec3640859a1eb5607c7a9392?pvs=4)




