### PR TITLE
[feat] 삭제한 메이트 처리 로직 구현

### DIFF
--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Interactor/MateListInteractor.swift
@@ -76,12 +76,8 @@ final class MateListInteractor: MateListInteractable {
     }
 
     func deleteMate(mate: Mate) async throws {
-        do {
-            try await deleteMateUseCase.execute(mate: mate)
-            presenter?.didDeleteMate(mate)
-        } catch {
-            throw SupabaseDBError.deleteDataFailed
-        }
+        try await deleteMateUseCase.execute(mate: mate)
+        presenter?.didDeleteMate(mate)
     }
 
     func bind() {

--- a/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Mate/MateList/Router/MateListRouter.swift
@@ -59,11 +59,12 @@ final class MateListRouter: MateListRoutable {
 
 extension MateListRouter: MateListBuildable {
     static func createMateListModule() -> UIViewController {
+        let networkProvider: SNMNetworkProvider = SNMNetworkProvider()
         let requestMateListUseCase: RequestMateListUseCase = RequestMateListUseCaseImpl(
             remoteDBManager: SupabaseDBManager.shared)
         let requestProfileImageUseCase: RequestProfileImageUseCase = RequestProfileImageUseCaseImpl(
             remoteImageManager: SupabaseStorageManager(
-                networkProvider: SNMNetworkProvider(),
+                networkProvider: networkProvider,
                 sessionManager: SupabaseSessionManager.shared
             ),
             cacheManager: CacheManager.shared
@@ -80,6 +81,7 @@ extension MateListRouter: MateListBuildable {
             mpcManager: mpcManager)
         let quitProfileDropUseCase: QuitProfileDropUseCase = QuitProfileDropUseCaseImpl(niManager: niManager)
         let deleteMateUseCase: DeleteMateUseCase = DeleteMateUseCaseImpl(
+            networkProvider: networkProvider,
             remoteDBManager: SupabaseDBManager.shared,
             sessionManager: SupabaseSessionManager.shared
         )

--- a/SniffMeet/SniffMeet/Source/PushNotification/PushNotificationRequest.swift
+++ b/SniffMeet/SniffMeet/Source/PushNotification/PushNotificationRequest.swift
@@ -9,6 +9,7 @@ import Foundation
 enum PushNotificationRequest {
     case sendWalkRequest(data: Data)
     case sendWalkRespond(data: Data)
+    case sendDeleteMate(senderID: String, receiverID: String)
 }
 
 extension PushNotificationRequest: SNMRequestConvertible {
@@ -24,6 +25,11 @@ extension PushNotificationRequest: SNMRequestConvertible {
             return Endpoint(baseURL: PushNotificationConfig.baseURL,
                             path: "notification/walkRespond",
                             method: .post)
+        case .sendDeleteMate(let senderID, let receiverID):
+            return Endpoint(baseURL: PushNotificationConfig.baseURL,
+                            path: "mate",
+                            method: .delete,
+                            query: ["senderID": senderID, "receiverID": receiverID])
         }
     }
     
@@ -39,6 +45,8 @@ extension PushNotificationRequest: SNMRequestConvertible {
         case .sendWalkRespond(let data):
             return SNMRequestType.compositePlain(header: header,
                                                  body: data)
+        case .sendDeleteMate:
+            return SNMRequestType.plain
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/DeleteMateUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/DeleteMateUseCase.swift
@@ -12,15 +12,18 @@ protocol DeleteMateUseCase {
 }
 
 final class DeleteMateUseCaseImpl: DeleteMateUseCase {
+    private let networkProvider: any NetworkProvider
     private let remoteDBManager: any RemoteDBManageable
     private let sessionManager: any SessionManageable
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
     init(
+        networkProvider: any NetworkProvider,
         remoteDBManager: any RemoteDBManageable,
         sessionManager: any SessionManageable
     ) {
+        self.networkProvider = networkProvider
         self.remoteDBManager = remoteDBManager
         self.sessionManager = sessionManager
     }
@@ -51,6 +54,13 @@ final class DeleteMateUseCaseImpl: DeleteMateUseCase {
                 .setData(updatedData)
                 .setQuery(.equal("id", userID))
                 .request()
+
+            _ = try await networkProvider.request(
+                with: PushNotificationRequest.sendDeleteMate(
+                    senderID: userID.uuidString,
+                    receiverID: mateID.uuidString
+                )
+            )
         } catch let error as SupabaseDBError where error == .fetchDataFailed || error == .updateDataFailed{
             throw SNMError(level: .user, error: error)
         } catch let error as SupabaseAuthError {


### PR DESCRIPTION
### 🔖  Issue Number

close #10 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
>
 
### 메이트 삭제 로직 
삭제된 메이트에 대한 처리 방법이 두 가지 선택지가 있었는데요. 
1. 산책 요청 로직만 자동으로 거부하게 만든다. 
2. 상대방 메이트 리스트에서도 자동으로 삭제한다. 

2번 방법을 선택했습니다. 
이유는 삭제된 메이트와 프로필 드랍을 다시 맺을 때 인터랙션은 양쪽에서 일어나게 될텐데,
한쪽은 이미 리스트에 메이트가 존재하고 한쪽은 존재하지 않는 부분이 개인적으로는 일관성이 떨어지는 느낌이 들더라구요. 
지금 로직에서 이 경우에 중복 데이터가 들어갈 가능성도 있어서 이렇게 처리했습니다.  

메이트 삭제 알림은 알림 리스트에 추가되지 않고 알림 터치 시 화면 전환도 별도로 구현하지는 않았습니다. 


### 시뮬레이션 

![deleteMate](https://github.com/user-attachments/assets/de654b44-e2df-4762-9305-5be3e21f3d02)


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 

- Push Notification Server의 리포지토리를 개설했습니다. 정돈이 안 된 Vapor 코드가 궁금하시다면 해당 레포를 참고하시면 좋을 것 같습니다. 
팀 레포가 생기니 좋네요~

https://github.com/Team-HGD/SniffMEET_Notification