### PR TITLE
[chore] 설정 파일 추가 

### DIFF
--- a/.github/workflows/dev_test.yml
+++ b/.github/workflows/dev_test.yml
@@ -37,6 +37,7 @@ jobs:
           touch SniffMeet/SniffMeet/Resource/Debug.xcconfig
           echo "SERVER_URL" = ${{ secrets.SERVER_URL }} >> SniffMeet/SniffMeet/Resource/Debug.xcconfig
           echo "PUBLIC_KEY" = ${{ secrets.PUBLIC_KEY }} >> SniffMeet/SniffMeet/Resource/Debug.xcconfig
+          echo "NOTIFICATION_SERVER" = ${{ secrets.NOTIFICATION_SERVER }} >> SniffMeet/SniffMeet/Resource/Debug.xcconfig
       - name: List available devices
         run: xcrun simctl list devices
       - name: Install SwiftLint

--- a/.github/workflows/dev_test.yml
+++ b/.github/workflows/dev_test.yml
@@ -34,8 +34,9 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_16.0.app
       - name: Create .xcconfig file
         run: |
-          echo "SERVER_URL" = ${{ secrets.SERVER_URL }} >> SniffMeet/Resource/Debug.xcconfig
-          echo "PUBLIC_KEY" = ${{ secrets.PUBLIC_KEY }} >> SniffMeet/Resource/Debug.xcconfig
+          touch SniffMeet/SniffMeet/Resource/Debug.xcconfig
+          echo "SERVER_URL" = ${{ secrets.SERVER_URL }} >> SniffMeet/SniffMeet/Resource/Debug.xcconfig
+          echo "PUBLIC_KEY" = ${{ secrets.PUBLIC_KEY }} >> SniffMeet/SniffMeet/Resource/Debug.xcconfig
       - name: List available devices
         run: xcrun simctl list devices
       - name: Install SwiftLint

--- a/.github/workflows/dev_test.yml
+++ b/.github/workflows/dev_test.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Select Xcode 16.0
         run: |
           sudo xcode-select -s /Applications/Xcode_16.0.app
+      - name: Create .xcconfig file
+        run: |
+          echo "SERVER_URL" = ${{ secrets.SERVER_URL }} >> SniffMeet/Resource/Debug.xcconfig
+          echo "PUBLIC_KEY" = ${{ secrets.PUBLIC_KEY }} >> SniffMeet/Resource/Debug.xcconfig
       - name: List available devices
         run: xcrun simctl list devices
       - name: Install SwiftLint

--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,6 @@ xcuserdata/
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
 
+*.xcconfig
+
 # End of https://www.toptal.com/developers/gitignore/api/xcode,macos,fastlane

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -714,6 +714,8 @@
 		FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNMPersistenceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD69B1CA2CE3E9B4009D71DC /* UserDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsTests.swift; sourceTree = "<group>"; };
 		FD69B1CC2CE3E9B8009D71DC /* KeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
+		FD6C73E32D5BC26A00E7AB14 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		FD6C73E42D5BC27C00E7AB14 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		FD880B592CECE8F90093BEB9 /* SNMLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMLogger.swift; sourceTree = "<group>"; };
 		FD880B5F2CF432780093BEB9 /* SaveProfileImageUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveProfileImageUseCase.swift; sourceTree = "<group>"; };
 		FD880B612CF433AC0093BEB9 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
@@ -727,6 +729,7 @@
 		FDBFA99E2CE1E50900AA9220 /* SNMFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMFont.swift; sourceTree = "<group>"; };
 		FDBFA9A02CE1E51000AA9220 /* SNMColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMColor.swift; sourceTree = "<group>"; };
 		FDBFA9B02CE1FDED00AA9220 /* LayoutConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConstant.swift; sourceTree = "<group>"; };
+		FDC5D9B92D5BD5D900380533 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FDCD02BE2CE9172600B627D8 /* SNMNetworkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNMNetworkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDCD02CD2CE917D400B627D8 /* MockRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequest.swift; sourceTree = "<group>"; };
 		FDCD02D02CE917E200B627D8 /* MockURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocol.swift; sourceTree = "<group>"; };
@@ -1213,6 +1216,7 @@
 		FD331A6F2CF33C7B00F39426 /* SupabaseTests */ = {
 			isa = PBXGroup;
 			children = (
+				FDC5D9B92D5BD5D900380533 /* Info.plist */,
 				FD331A712CF33C7F00F39426 /* SupabaseStorageTests.swift */,
 			);
 			path = SupabaseTests;
@@ -1325,6 +1329,8 @@
 			children = (
 				99A5A1B22CFFE544002F1D2D /* ProfileDrop.gif */,
 				FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */,
+				FD6C73E42D5BC27C00E7AB14 /* Release.xcconfig */,
+				FD6C73E32D5BC26A00E7AB14 /* Debug.xcconfig */,
 				FD3A033A2CD8CF460047B7ED /* Info.plist */,
 				FD3A03392CD8CF460047B7ED /* Assets.xcassets */,
 			);
@@ -2984,11 +2990,13 @@
 		};
 		FD331A6C2CF33C6700F39426 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD6C73E32D5BC26A00E7AB14 /* Debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SupabaseTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sole.SupabaseTests;
@@ -2997,6 +3005,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited) TEST";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -3005,11 +3014,13 @@
 		};
 		FD331A6D2CF33C6700F39426 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD6C73E42D5BC27C00E7AB14 /* Release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SupabaseTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sole.SupabaseTests;
@@ -3018,6 +3029,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TEST;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -3026,6 +3038,7 @@
 		};
 		FD3A03342CD8CDE60047B7ED /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD6C73E32D5BC26A00E7AB14 /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3064,6 +3077,7 @@
 		};
 		FD3A03352CD8CDE60047B7ED /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD6C73E42D5BC27C00E7AB14 /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3102,6 +3116,7 @@
 		};
 		FD3A03362CD8CDE60047B7ED /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD6C73E32D5BC26A00E7AB14 /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -3165,6 +3180,7 @@
 		};
 		FD3A03372CD8CDE60047B7ED /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FD6C73E42D5BC27C00E7AB14 /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -3313,7 +3329,7 @@
 				32BD482F2D3FEC9D0078DA9C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		A24B1F2D2D3C32960012B860 /* Build configuration list for PBXNativeTarget "SNMUtilityTests" */ = {
 			isa = XCConfigurationList;
@@ -3322,7 +3338,7 @@
 				A24B1F2C2D3C32960012B860 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		FD331A6B2CF33C6700F39426 /* Build configuration list for PBXNativeTarget "SupabaseTests" */ = {
 			isa = XCConfigurationList;
@@ -3331,7 +3347,7 @@
 				FD331A6D2CF33C6700F39426 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		FD3A031B2CD8CDE50047B7ED /* Build configuration list for PBXProject "SniffMeet" */ = {
 			isa = XCConfigurationList;
@@ -3340,7 +3356,7 @@
 				FD3A03372CD8CDE60047B7ED /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		FD3A03332CD8CDE60047B7ED /* Build configuration list for PBXNativeTarget "SniffMeet" */ = {
 			isa = XCConfigurationList;
@@ -3349,7 +3365,7 @@
 				FD3A03352CD8CDE60047B7ED /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		FD69B1C02CE3BCDC009D71DC /* Build configuration list for PBXNativeTarget "SNMPersistenceTests" */ = {
 			isa = XCConfigurationList;
@@ -3358,7 +3374,7 @@
 				FD69B1C22CE3BCDC009D71DC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		FDCD02C42CE9172600B627D8 /* Build configuration list for PBXNativeTarget "SNMNetworkTests" */ = {
 			isa = XCConfigurationList;
@@ -3367,7 +3383,7 @@
 				FDCD02C32CE9172600B627D8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 

--- a/SniffMeet/SniffMeet/Resource/Info.plist
+++ b/SniffMeet/SniffMeet/Resource/Info.plist
@@ -32,6 +32,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>SERVER_URL</key>
+	<string>$(SERVER_URL)</string>
+	<key>PUBLIC_KEY</key>
+	<string>$(PUBLIC_KEY)</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/SniffMeet/SniffMeet/Resource/Info.plist
+++ b/SniffMeet/SniffMeet/Resource/Info.plist
@@ -40,5 +40,7 @@
 	<array>
 		<string>remote-notification</string>
 	</array>
+	<key>NOTIFICATION_SERVER</key>
+	<string>$(NOTIFICATION_SERVER)</string>
 </dict>
 </plist>

--- a/SniffMeet/SniffMeet/Source/PushNotification/PushNotificationConfig.swift
+++ b/SniffMeet/SniffMeet/Source/PushNotification/PushNotificationConfig.swift
@@ -7,5 +7,11 @@
 import Foundation
 
 enum PushNotificationConfig {
-    static let baseURL = URL(string: "https://sniff.fly.dev")!
+    static let baseURL: URL = {
+        guard let serverURLString = Bundle.main.object(forInfoDictionaryKey: "NOTIFICATION_SERVER") as? String,
+              let serverURL = URL(string: serverURLString.replacingOccurrences(of: "\\", with: "")) else {
+            fatalError("invalid server url")
+        }
+        return serverURL
+    }()
 }

--- a/SniffMeet/SniffMeet/Source/Supabase/SupabaseConfig.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/SupabaseConfig.swift
@@ -8,7 +8,34 @@
 import Foundation
 
 enum SupabaseConfig {
-    static let baseURL = URL(string: "https://lltjsznuclppbhxfwslo.supabase.co")!
-    static let apiKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxsdGpzem51Y2xwcGJoeGZ3c2xvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzE0MDA5MjgsImV4cCI6MjA0Njk3NjkyOH0.qrzmB2tiwWevRhKQeptsf5m8iCLUIkscuQ1MzKNtqh4" // 공개키
+#if TEST
+    static let baseURL: URL = {
+        guard let urlString = Bundle(for: SupabaseStorageTests.self).object(forInfoDictionaryKey: "SERVER_URL") as? String,
+              let url = URL(string: urlString.replacingOccurrences(of: "\\", with: "")) else {
+            fatalError("invalid SERVER_URL")
+        }
+        return url
+    }()
+    static let apiKey: String = {
+        guard let publicKey = Bundle(for: SupabaseStorageTests.self).object(forInfoDictionaryKey: "PUBLIC_KEY") as? String else {
+            fatalError("invalid PUBLIC_KEY")
+        }
+        return publicKey
+    }()
+    #else
+    static let baseURL: URL = {
+        guard let urlString = Bundle.main.object(forInfoDictionaryKey: "SERVER_URL") as? String,
+              let url = URL(string: urlString.replacingOccurrences(of: "\\", with: "")) else {
+            fatalError("invalid SERVER_URL")
+        }
+        return url
+    }()
+    static let apiKey: String = {
+        guard let publicKey = Bundle.main.object(forInfoDictionaryKey: "PUBLIC_KEY") as? String else {
+            fatalError("invalid PUBLIC_KEY")
+        }
+        return publicKey
+    }()
+    #endif
     static let bucketName: String = "image"
 }

--- a/SniffMeet/SniffMeet/Source/Supabase/SupabaseConfig.swift
+++ b/SniffMeet/SniffMeet/Source/Supabase/SupabaseConfig.swift
@@ -22,7 +22,7 @@ enum SupabaseConfig {
         }
         return publicKey
     }()
-    #else
+#else
     static let baseURL: URL = {
         guard let urlString = Bundle.main.object(forInfoDictionaryKey: "SERVER_URL") as? String,
               let url = URL(string: urlString.replacingOccurrences(of: "\\", with: "")) else {

--- a/SniffMeet/SupabaseTests/Info.plist
+++ b/SniffMeet/SupabaseTests/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PUBLIC_KEY</key>
+	<string>$(PUBLIC_KEY)</string>
+	<key>SERVER_URL</key>
+	<string>$(SERVER_URL)</string>
+</dict>
+</plist>


### PR DESCRIPTION
### 🔖  Issue Number

close #9

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 

### Test DB Drop 
Test DB Drop을 완료했습니다. Authentication도 모두 삭제되었습니다. 

### .config 파일 설정 
Debug / Release 에 따라 각각 Debug.config / Release.config 파일을 쓸수 있도록 설정했습니다. 
Info.plist에서는 해당 설정 파일에서 SERVER_URL과 PUBLIC_KEY를 불러오게 됩니다. 

![image](https://github.com/user-attachments/assets/3a1f7251-c5ed-49ea-a397-cffc714d1832)

.config 파일은 깃허브에 올라가면 안돼서 로컬에서만 사용할 수 있도록 .gitignore에 .config를 추가했습니다. 
파일은 노션이나 슬랙으로 공유하겠습니다. 

### 테스트

baseURL를 불러오는 코드가 많이 번잡해졌는데요. 이유는 SupabaseTests 때문입니다... 
이 테스트를 진행할 때 baseURL을 사용하게 됩니다. 

문제는 Bundle.main을 사용할 수 없더라구요. 
SupabaseTests Target > Build Settings > Swift Compiler Custom Flag 에 전처리기 시그니처(TEST)를 추가했습니다. 

![image](https://github.com/user-attachments/assets/f4633dc8-f253-4986-9842-d617ad5d2fe5)

SupabaseTests가 수행될때만  Bundle(for: SupabaseStorage.self)로 Info.plist를 읽어옵니다. 
이 부분 때문에 SupabaseTests에 새로운 Info.plist가 추가되어 있습니다. 

![image](https://github.com/user-attachments/assets/3c2c2733-58c1-4159-8a5d-7cad15bfe4f4)


### CI 

CI 환경에서도 로컬에서와 같이 .config 파일을 찾을 수 없습니다. 해당 파일을 테스트마다 생성해주는 작업이 필요합니다. 
Repository Settings > Secrets 에 SERVER_URL / PUBLIC_KEY를 등록해두었습니다. 
work_flow에 .config 파일 생성 및 Secret 값 붙여넣기 과정을 추가했습니다. 
