### PR TITLE
[feature] 산책로그 기록 측정하는 유즈케이즈 적용

### DIFF
--- a/SniffMeet/SniffMeet/Source/Entity/WalkRoute.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/WalkRoute.swift
@@ -13,4 +13,8 @@ struct WalkRoute {
     
     private(set) var points: [CLLocationCoordinate2D] = []
     var count: Int { points.count }
+    
+    mutating func append(_ coordinate: CLLocationCoordinate2D) {
+        points.append(coordinate)
+    }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
@@ -88,9 +88,11 @@ final class TrackWalkInteractor: TrackWalkInteractable {
 
         if locations.count > 1 {
             let lastLocation = self.locations[locations.count - 2]
+            let coordinate = location.coordinate
             let distance = location.distance(from: lastLocation)
             totalDistance += distance
-            // TODO: - WalkRoute에 경로 coordinate 추가
+            walkRoute.append(coordinate)
+            presenter?.updateLocation(with: walkRoute)
         }
         SNMLogger.log("이동 거리: \(totalDistance) meters")
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
@@ -17,9 +17,9 @@ protocol TrackWalkInteractable: AnyObject {
 
 final class TrackWalkInteractor: TrackWalkInteractable {
     weak var presenter: (any TrackWalkInteractorOutput)?
-    private let updateTimeUseCase: UpdateTimeUseCase
-    private let updateUserStepUseCase: UpdateUserStepUseCase
-    private let updateUserLocationUseCase: UpdateUserLocationUseCase
+    private let updateTimeUseCase: any UpdateTimeUseCase
+    private let updateUserStepUseCase: any UpdateUserStepUseCase
+    private let updateUserLocationUseCase: any UpdateUserLocationUseCase
 
     private var startDate: Date?
     private var endDate: Date?
@@ -31,9 +31,9 @@ final class TrackWalkInteractor: TrackWalkInteractable {
     private var cancellables = Set<AnyCancellable>()
 
     init(
-        updateTimeUseCase: UpdateTimeUseCase,
-        updateUserStepUseCase: UpdateUserStepUseCase,
-        updateUserLocationUseCase: UpdateUserLocationUseCase
+        updateTimeUseCase: any UpdateTimeUseCase,
+        updateUserStepUseCase: any UpdateUserStepUseCase,
+        updateUserLocationUseCase: any UpdateUserLocationUseCase
     ){
         self.updateTimeUseCase = updateTimeUseCase
         self.updateUserStepUseCase = updateUserStepUseCase

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
@@ -4,12 +4,111 @@
 //
 //  Created by 윤지성 on 2/18/25.
 //
+import Combine
+import CoreLocation
+import Foundation
 
 protocol TrackWalkInteractable: AnyObject {
     var presenter: TrackWalkInteractorOutput? { get set }
 
+    func startTracking()
+    func stopTracking() -> WalkLog?
 }
 
 final class TrackWalkInteractor: TrackWalkInteractable {
     weak var presenter: (any TrackWalkInteractorOutput)?
+    private let updateTimeUseCase: UpdateTimeUseCase
+    private let updateUserStepUseCase: UpdateUserStepUseCase
+    private let updateUserLocationUseCase: UpdateUserLocationUseCase
+
+    private var startDate: Date?
+    private var endDate: Date?
+    private var time: TimeInterval = 0.0
+    private var stepCount: Int = 0
+    private var totalDistance: Double = 0.0
+    private var locations: [CLLocation] = []
+    private var walkRoute = WalkRoute(points: [])
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        updateTimeUseCase: UpdateTimeUseCase,
+        updateUserStepUseCase: UpdateUserStepUseCase,
+        updateUserLocationUseCase: UpdateUserLocationUseCase
+    ){
+        self.updateTimeUseCase = updateTimeUseCase
+        self.updateUserStepUseCase = updateUserStepUseCase
+        self.updateUserLocationUseCase = updateUserLocationUseCase
+    }
+
+    func startTracking() {
+        startDate = Date()
+
+        updateTimeUseCase.execute()
+        updateUserStepUseCase.execute()
+        updateUserLocationUseCase.execute()
+
+        binding()
+    }
+
+    private func binding() {
+        updateTimeUseCase.elapsedTimePublisher
+            .sink { [weak self] elapsedTime in
+                guard let self = self else { return }
+                self.time = elapsedTime
+                self.updateWalkRecord()
+                SNMLogger.log("경과 시간: \(self.time) seconds")
+            }
+            .store(in: &cancellables)
+        updateUserStepUseCase.stepCountPublisher
+            .sink { [weak self] step in
+                guard let self = self else { return }
+                self.stepCount = step
+                SNMLogger.log("걸음 수: \(self.stepCount) steps")
+            }
+            .store(in: &cancellables)
+        updateUserLocationUseCase.locationPublisher
+            .sink { [weak self] location in
+                guard let self = self else { return }
+                self.calculateDistance(location)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateWalkRecord() {
+        let record = WalkRecord(
+            stepCount: stepCount,
+            totalDistance: totalDistance,
+            time: time
+        )
+        presenter?.updateWalkRecord(record)
+    }
+
+    private func calculateDistance(_ location: CLLocation) {
+        locations.append(location)
+
+        if locations.count > 1 {
+            let lastLocation = self.locations[locations.count - 2]
+            let distance = location.distance(from: lastLocation)
+            totalDistance += distance
+            // TODO: - WalkRoute에 경로 coordinate 추가
+        }
+        SNMLogger.log("이동 거리: \(totalDistance) meters")
+    }
+
+    func stopTracking() -> WalkLog? {
+        endDate = Date()
+        updateTimeUseCase.cancel()
+        updateUserStepUseCase.cancel()
+        updateUserLocationUseCase.cancel()
+
+        guard let startDate = startDate, let endDate = endDate else { return nil }
+
+        return WalkLog(
+            step: stepCount,
+            distance: totalDistance,
+            startDate: startDate,
+            endDate: endDate,
+            image: nil
+        )
+    }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
@@ -16,18 +16,14 @@ protocol TrackWalkPresentable: AnyObject {
 }
 protocol TrackWalkInteractorOutput: AnyObject {
     func updateWalkRecord(_ record: WalkRecord)
+    func updateLocation(with walkLocation: WalkRoute)
 }
 
 final class TrackWalkViewPresenter: TrackWalkPresentable {
     weak var view: (any TrackWalkViewable)?
     var interactor: (any TrackWalkInteractable)?
     var router: (any TrackWalkRoutable)?
-    
-    func updateLocation(with walkLocation: WalkRoute) {
-        Task { @MainActor [weak self]  in
-            self?.view?.updateRouteLine(with: walkLocation)
-        }
-    }
+
     func startTracking() {
         interactor?.startTracking()
     }
@@ -40,5 +36,10 @@ final class TrackWalkViewPresenter: TrackWalkPresentable {
 extension TrackWalkViewPresenter: TrackWalkInteractorOutput {
     func updateWalkRecord(_ record: WalkRecord) {
         view?.updateWalkRecord(record: record)
+    }
+    func updateLocation(with walkLocation: WalkRoute) {
+        Task { @MainActor [weak self]  in
+            self?.view?.updateRouteLine(with: walkLocation)
+        }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
@@ -10,12 +10,12 @@ protocol TrackWalkPresentable: AnyObject {
     var view: (any TrackWalkViewable)? { get set }
     var interactor: (any TrackWalkInteractable)? { get set }
     var router: (any TrackWalkRoutable)? { get set }
-    
-    func updateLocation(with walkLocation: WalkRoute)
+
     func startTracking()
     func endTracking()
 }
 protocol TrackWalkInteractorOutput: AnyObject {
+    func updateWalkRecord(_ record: WalkRecord)
 }
 
 final class TrackWalkViewPresenter: TrackWalkPresentable {
@@ -29,7 +29,7 @@ final class TrackWalkViewPresenter: TrackWalkPresentable {
         }
     }
     func startTracking() {
-        
+        interactor?.startTracking()
     }
     func endTracking() {
         // TODO: -  인터랙터에 저장 요청하는 로직
@@ -38,5 +38,7 @@ final class TrackWalkViewPresenter: TrackWalkPresentable {
 }
 
 extension TrackWalkViewPresenter: TrackWalkInteractorOutput {
-    
+    func updateWalkRecord(_ record: WalkRecord) {
+        view?.updateWalkRecord(record: record)
+    }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Router/TrackWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Router/TrackWalkRouter.swift
@@ -4,6 +4,7 @@
 //
 //  Created by 윤지성 on 2/18/25.
 //
+import CoreLocation
 import UIKit
 
 protocol TrackWalkRoutable: AnyObject, Routable {
@@ -28,9 +29,16 @@ protocol TrackWalkModuleBuildable {
 
 extension TrackWalkRouter: TrackWalkModuleBuildable {
     static func create() -> UIViewController {
+        let updateTimeUseCase: UpdateTimeUseCase = UpdateTimeUseCaseImpl()
+        let updateUserStepUseCase: UpdateUserStepUseCase = UpdateUserStepUseCaseImpl()
+        let updateUserLocationUseCase: UpdateUserLocationUseCase = UpdateUserLocationUseCaseImpl(
+            locationManager: CLLocationManager())
         let view: TrackWalkViewable & UIViewController = TrackWalkViewController()
         let presenter: TrackWalkPresentable & TrackWalkInteractorOutput = TrackWalkViewPresenter()
-        let interactor: TrackWalkInteractable = TrackWalkInteractor()
+        let interactor: TrackWalkInteractable = TrackWalkInteractor(
+            updateTimeUseCase: updateTimeUseCase,
+            updateUserStepUseCase: updateUserStepUseCase,
+            updateUserLocationUseCase: updateUserLocationUseCase)
         let router: TrackWalkRoutable & TrackWalkModuleBuildable = TrackWalkRouter()
         
         view.presenter = presenter

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
@@ -23,6 +23,7 @@ final class TrackWalkViewController: BaseViewController {
     private let mapView: MKMapView = {
         let mapView: MKMapView = MKMapView()
         mapView.showsUserLocation = true
+        mapView.setUserTrackingMode(.follow, animated: true)
         mapView.cameraZoomRange = .init(
             minCenterCoordinateDistance: 1000,
             maxCenterCoordinateDistance: 5000
@@ -43,6 +44,11 @@ final class TrackWalkViewController: BaseViewController {
     private let verticalSeparator = UIView()
     private var routeMapImageView: UIImageView = UIImageView()
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.mapView.delegate = self
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         trackingButton.layoutIfNeeded()
         trackingButton.makeViewCircular()

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
@@ -12,7 +12,7 @@ protocol TrackWalkViewable: AnyObject {
     var presenter: TrackWalkPresentable? { get set }
     
     func updateRouteLine(with location: WalkRoute)
-    func updateWalkRecord()
+    func updateWalkRecord(record: WalkRecord)
 }
 
 final class TrackWalkViewController: BaseViewController {
@@ -213,9 +213,11 @@ extension TrackWalkViewController: TrackWalkViewable {
         let lineDraw = MKPolyline(coordinates: location.points, count: location.count)
         mapView.addOverlay(lineDraw)
     }
-    // TODO: -  1초 마다 업데이트하기
-    func updateWalkRecord() {
-        
+
+    func updateWalkRecord(record: WalkRecord) {
+        timeValueLabel.text = record.formattedTime.description
+        distanceValueLabel.text = record.distance.description
+        numberOfStepsValueLabel.text = record.stepCount.description
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/UseCase/UpdateUseCase/UpdateTimeUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/UpdateUseCase/UpdateTimeUseCase.swift
@@ -4,32 +4,43 @@
 //
 //  Created by 배현진 on 2/18/25.
 //
+import Combine
 import Foundation
 
 protocol UpdateTimeUseCase {
-    func startTimer(update: @escaping (TimeInterval) -> Void)
-    func stopTimer()
+    var elapsedTimePublisher: AnyPublisher<TimeInterval, Never> { get }
+
+    func execute()
+    func cancel()
 }
 
 final class UpdateTimeUseCaseImpl: UpdateTimeUseCase {
     private var timer: Timer?
     private var startTime: Date?
+    private var elapsedTimeSubject = PassthroughSubject<TimeInterval, Never>()
 
-    func startTimer(update: @escaping (TimeInterval) -> Void) {
+    var elapsedTimePublisher: AnyPublisher<TimeInterval, Never> {
+        elapsedTimeSubject.eraseToAnyPublisher()
+    }
+
+    func execute() {
         startTime = Date()
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+        timer = Timer.scheduledTimer(
+            withTimeInterval: 1.0,
+            repeats: true
+        ) { [weak self] _ in
             guard let startTime = self?.startTime else { return }
             let elapsedTime = Date().timeIntervalSince(startTime)
-            update(elapsedTime)
+            self?.elapsedTimeSubject.send(elapsedTime)
         }
     }
 
-    func stopTimer() {
+    func cancel() {
         timer?.invalidate()
         timer = nil
     }
 
     deinit {
-        stopTimer()
+        cancel()
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/UpdateUseCase/UpdateUserLocationUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/UpdateUseCase/UpdateUserLocationUseCase.swift
@@ -4,17 +4,23 @@
 //
 //  Created by sole on 11/19/24.
 //
-
+import Combine
 import CoreLocation
 
 protocol UpdateUserLocationUseCase {
-    func startUpdateLocation(updateHandler: @escaping (CLLocation) -> Void)
-    func stopUpdateLocation()
+    var locationPublisher: AnyPublisher<CLLocation, Never> { get }
+
+    func execute()
+    func cancel()
 }
 
 final class UpdateUserLocationUseCaseImpl: NSObject, UpdateUserLocationUseCase {
     private let locationManager: CLLocationManager
-    private var updateHandler: ((CLLocation) -> Void)?
+    private var locationSubject = PassthroughSubject<CLLocation, Never>()
+
+    var locationPublisher: AnyPublisher<CLLocation, Never> {
+        locationSubject.eraseToAnyPublisher()
+    }
 
     init(locationManager: CLLocationManager) {
         self.locationManager = locationManager
@@ -28,20 +34,18 @@ final class UpdateUserLocationUseCaseImpl: NSObject, UpdateUserLocationUseCase {
         locationManager.requestWhenInUseAuthorization()
     }
 
-    func startUpdateLocation(updateHandler: @escaping (CLLocation) -> Void) {
-        self.updateHandler = updateHandler
+    func execute() {
         locationManager.startUpdatingLocation()
     }
 
-    func stopUpdateLocation() {
-        updateHandler = nil
+    func cancel() {
         locationManager.stopUpdatingLocation()
     }
 }
 
 extension UpdateUserLocationUseCaseImpl: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        guard let location = locations.last, let handler = updateHandler else { return }
-        handler(location)
+        guard let location = locations.last else { return }
+        locationSubject.send(location)
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/UpdateUseCase/UpdateUserStepUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/UpdateUseCase/UpdateUserStepUseCase.swift
@@ -4,34 +4,42 @@
 //
 //  Created by 배현진 on 2/18/25.
 //
+import Combine
 import CoreMotion
 
 protocol UpdateUserStepUseCase {
-    func startUpdateStepCount(update: @escaping (Int) -> Void)
-    func stopUpdateStepCount()
+    var stepCountPublisher: AnyPublisher<Int, Never> { get }
+
+    func execute()
+    func cancel()
 }
 
 final class UpdateUserStepUseCaseImpl: UpdateUserStepUseCase {
     private let pedometer = CMPedometer()
     private var pedometerIsUpdating: Bool = false
+    private let stepCountSubject = PassthroughSubject<Int, Never>()
 
-    func startUpdateStepCount(update: @escaping (Int) -> Void) {
+    var stepCountPublisher: AnyPublisher<Int, Never> {
+        stepCountSubject.eraseToAnyPublisher()
+    }
+
+    func execute() {
         if pedometerIsUpdating {
-            stopUpdateStepCount()
+            cancel()
             pedometerIsUpdating = false
         }
 
         guard CMPedometer.isStepCountingAvailable() else { return }
 
         pedometerIsUpdating = true
-        pedometer.startUpdates(from: Date()) { data, error in
+        pedometer.startUpdates(from: Date()) { [weak self] data, error in
         //TODO: - 에러 구체화 필요
             guard error == nil, let data = data else { return }
-            update(data.numberOfSteps.intValue)
+            self?.stepCountSubject.send(data.numberOfSteps.intValue)
         }
     }
 
-    func stopUpdateStepCount() {
+    func cancel() {
         pedometer.stopUpdates()
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

#45

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x] 시간측정 유즈케이스 연결
- [x] 위치 측정 유즈케이스 연결
- [x] 걸음수 측정 유즈케이스 연결
- [x] 위치를 기반으로 이동 거리 파악
- [x] 위치를 기반으로 mapView에 경로 표시


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- #37 번 PR에서 클로저 Combine으로 변경하고, 유즈케이스 함수명 변경해서 커밋 날린 후 푸시를 안하고 머지해서.. 해당 PR에서 추가 적업했습니다.

- 경로 맵뷰에 표시 결과
집에서 확인한 결과, 경로가 잘 표시되었습니다.
좀 더 정확한 확인 위해 산책 갔다와서 결과물 추가 작성하겠습니다.

(추가) 실외에서 이동하며 측정한 결과입니다. 평균 속도는 걸음수입니다(이전 뷰 사용해 테스트했기때문에 다릅니다.)

<img width = 300 src = "https://github.com/user-attachments/assets/9457b708-1741-4c1a-903d-64b76c683eb1">


- 측정 결과를 화면에 표시하기 위주의 유즈케이스 적용을 진행했습니다.
측정 결과를 최종적으로 저장하고, 성공시 산책기록이 종료되는 부분 추가구현 한 뒤 해당 PR에서 이슈 닫으면 될 것 같습니다.


