### PR TITLE
[feat/test] 산책로그 저장 / 불러오기 유즈케이스 구현

### DIFF
--- a/SniffMeet/SNMPersistenceTests/FileManagerTest.swift
+++ b/SniffMeet/SNMPersistenceTests/FileManagerTest.swift
@@ -8,91 +8,227 @@
 import XCTest
 
 final class FileManagerTest: XCTestCase {
-    private var fileManagersut: SNMFileManager!
+    private var imageFileManagersut: SNMFileManager!
+    private var dataFileManagerSut: SNMFileManager!
+
     private let testKey = "profileTest"
     private var isSaved = false
+    private let testDirectoryPath: String = "test"
+    private let testDirectoryPaths: [String] = [
+        "test/\(UUID().uuidString)",
+        "test/\(UUID().uuidString)",
+        "test/\(UUID().uuidString)"
+    ]
 
     override func setUp()  {
-        fileManagersut = SNMFileManager(fileType: .data)
+        imageFileManagersut = SNMFileManager(fileType: .image)
+        dataFileManagerSut = SNMFileManager(fileType: .data)
     }
 
     override func tearDownWithError() throws {
-        if isSaved {
-            try fileManagersut.delete(forKey: testKey)
-        }
-        isSaved = false
+        try? imageFileManagersut.delete(forKey: testKey)
+        try? dataFileManagerSut.deleteAll(directoryPath: testDirectoryPath)
+        try? imageFileManagersut.deleteAll(directoryPath: testDirectoryPath)
     }
-//    func test_delete에서_삭제할_값이_없으면_에러를_반환한다() throws {
-//        XCTAssertThrowsError(try fileManagersut.delete(forKey: testKey)) { error in
-//            guard let error = error as? FileManagerError else {
-//                XCTFail("error is not FileManagerError")
-//                return
-//            }
-//            XCTAssertEqual(error, FileManagerError.deleteError)
 
-//        }
-//    }
-    
-//    func test_이미지를_저장하고_가져올_수_있다() throws {
-//        // Arrange
-//        let image: UIImage = .app
-//
-//        // Act
-//        XCTAssertFalse(fileManagersut.fileExists(forKey: testKey))
-//        if let imageData = image.jpegData(compressionQuality: 1.0) {
-//            try fileManagersut.set(data: imageData, forKey: testKey)
-//        }
-//        guard let savedImage = try fileManagersut.get(forKey: testKey) else { XCTFail(); return}
-//        isSaved = true
-//        // Assert
-//        XCTAssertTrue(fileManagersut.fileExists(forKey: testKey))
-//    }
-//    
-//    func test_이미_이미지가_저장된파일에_이미지를_덮어쓸_수_있다() throws {
-//        // Arrange
-//        let firstImage: UIImage = .app
-//        let secondImage: UIImage = .imagePlaceholder
-//
-//        // Act
-//        try fileManagersut.set(image: firstImage, forKey: testKey)
-//        guard let firstSavedImage = try fileManagersut.get(forKey: testKey) else {
-//            XCTFail()
-//            return
-//        }
-//        
-//        try fileManagersut.set(image: secondImage, forKey: testKey)
-//        guard let secondSavedImage = try fileManagersut.get(forKey: testKey) else {
-//            XCTFail()
-//            return
-//        }
-//        isSaved = true
-//        
-//        //Assert
-//        let comparison1 = firstImage.pngData()?.count ?? 0 > secondImage.pngData()?.count ?? 0
-//        let comparison2 = firstSavedImage.pngData()?.count ?? 0 > secondSavedImage.pngData()?.count ?? 0
-//        
-//        XCTAssertTrue(fileManagersut.fileExists(forKey: testKey))
-//        XCTAssertEqual(comparison1, comparison2)
-//    }
-//    
-//    func test_데이터가_삭제될_수_있다() throws {
-//        // Arrange
-//        let firstImage: UIImage = .app
-//
-//        // Act
-//        try fileManagersut.set(image: firstImage, forKey: testKey)
-//        guard let beforeSavedImage = try fileManagersut.get(forKey: testKey) else {
-//            XCTFail()
-//            return
-//        }
-//        
-//        try fileManagersut.delete(forKey: testKey)
-//        
-//        //Assert
-//        XCTAssertThrowsError(try fileManagersut.delete(forKey: testKey)) { error in
-//            XCTAssert(error is FileManagerError)
-//            XCTAssertEqual(error as! FileManagerError, FileManagerError.deleteError)
-//        }
-//    }
+    func test_set에서_key에_설정한_폴더가_없으면_폴더를_생성한다() throws {
+        // Arrange
+        XCTAssertFalse(
+            dataFileManagerSut.fileExists(forKey: testDirectoryPath, isDirectory: true)
+        )
+        let encodedData = try JSONEncoder().encode([1, 2, 3])
+        // Act
+        try dataFileManagerSut.set(value: encodedData, forKey: testDirectoryPaths[0])
+        // Assert
+        XCTAssertTrue(
+            dataFileManagerSut.fileExists(forKey: testDirectoryPath, isDirectory: true)
+        )
+    }
 
+    func test_delete에서_삭제할_값이_없으면_에러를_반환한다() throws {
+        XCTAssertThrowsError(try imageFileManagersut.delete(forKey: testKey)) { error in
+            guard let error = error as? FileManagerError else {
+                XCTFail("error is not FileManagerError")
+                return
+            }
+            XCTAssertEqual(error, FileManagerError.deleteError)
+        }
+    }
+
+    func test_이미지를_저장하고_가져올_수_있다() throws {
+        // Arrange
+        let image: UIImage = .app
+
+        // Act
+        XCTAssertFalse(imageFileManagersut.fileExists(forKey: testKey))
+        if let imageData = image.jpegData(compressionQuality: 1.0) {
+            try imageFileManagersut.set(value: imageData, forKey: testKey)
+        }
+        _ = try imageFileManagersut.get(forKey: testKey)
+        isSaved = true
+        // Assert
+        XCTAssertTrue(imageFileManagersut.fileExists(forKey: testKey))
+    }
+
+    func test_이미_이미지가_저장된파일에_이미지를_덮어쓸_수_있다() throws {
+        // Arrange
+        let firstImage: UIImage = .app
+        let secondImage: UIImage = .imagePlaceholder
+
+        // Act
+        try imageFileManagersut.set(value: firstImage.pngData()!, forKey: testKey)
+        let firstSavedImageData = try imageFileManagersut.get(forKey: testKey)
+
+        try imageFileManagersut.set(value: secondImage.pngData()!, forKey: testKey)
+        let secondSavedImageData = try imageFileManagersut.get(forKey: testKey)
+        isSaved = true
+
+        //Assert
+        let comparison1 = firstImage.pngData()?.count ?? 0 > secondImage.pngData()?.count ?? 0
+        let comparison2 = firstSavedImageData.count > secondSavedImageData.count
+
+        XCTAssertTrue(imageFileManagersut.fileExists(forKey: testKey))
+        XCTAssertEqual(comparison1, comparison2)
+    }
+
+    func test_데이터가_삭제될_수_있다() throws {
+        // Arrange
+        let firstImage: UIImage = .app
+
+        // Act
+        try imageFileManagersut.set(value: firstImage.pngData()!, forKey: testKey)
+        let beforeSavedImage = try imageFileManagersut.get(forKey: testKey)
+
+        try imageFileManagersut.delete(forKey: testKey)
+
+        //Assert
+        XCTAssertThrowsError(try imageFileManagersut.delete(forKey: testKey)) { error in
+            XCTAssert(error is FileManagerError)
+            XCTAssertEqual(error as! FileManagerError, FileManagerError.deleteError)
+        }
+    }
+
+    func test_fileExists에서_파일이_존재하는_경로에는_true를_반환한다() throws {
+        // Arrange
+        let encodedData = try JSONEncoder().encode([1, 2, 3])
+        try dataFileManagerSut.set(value: encodedData, forKey: testDirectoryPaths[0])
+        // Act
+        let isExist = dataFileManagerSut.fileExists(forKey: testDirectoryPaths[0])
+        // Assert
+        XCTAssertTrue(isExist)
+    }
+    func test_fileExists에서_파일이_존재하지_않는_경로에는_false를_반환한다() throws {
+        // Arrange
+        // Act
+        let isExist = dataFileManagerSut.fileExists(forKey: testDirectoryPaths[0])
+        // Assert
+        XCTAssertFalse(isExist)
+    }
+    func test_fileExists에서_디렉토리가_존재하는_경로에는_true를_반환한다() throws {
+        // Arrange
+        let encodedData = try JSONEncoder().encode([1, 2, 3])
+        try dataFileManagerSut.set(value: encodedData, forKey: testDirectoryPaths[0])
+        // Act
+        let isExist = dataFileManagerSut.fileExists(forKey: testDirectoryPath, isDirectory: true)
+        // Assert
+        XCTAssertTrue(isExist)
+    }
+    func test_fileExists에서_디렉토리가_존재하지_않는_경로에는_false를_반환한다() throws {
+        // Arrange
+        // Act
+        let isExist = dataFileManagerSut.fileExists(
+            forKey: testDirectoryPath,
+            isDirectory: true
+        )
+        // Assert
+        XCTAssertFalse(isExist)
+    }
+    func test_fileExists에서_이미지파일경로를_입력하고_isDirectory를_true로_설정하면_false를_반환한다() throws {
+        // Arrange
+        let image: UIImage = .app
+        try imageFileManagersut.set(value: image.pngData()!, forKey: testDirectoryPaths[0])
+        // Act
+        let isExist = imageFileManagersut.fileExists(
+            forKey: testDirectoryPaths[0],
+            isDirectory: true
+        )
+        // Assert
+        XCTAssertFalse(isExist)
+    }
+    func test_fileExists에서_데이터파일경로를_입력하고_isDirectory를_true로_설정하면_false를_반환한다() throws {
+        // Arrange
+        let encodedData = try JSONEncoder().encode([1, 2, 3])
+        try imageFileManagersut.set(value: encodedData, forKey: testDirectoryPaths[0])
+        // Act
+        let isExist = imageFileManagersut.fileExists(
+            forKey: testDirectoryPaths[0],
+            isDirectory: true
+        )
+        // Assert
+        XCTAssertFalse(isExist)
+    }
+
+    func test_getAll에서_디렉토리에_저장한_데이터를_모두_불러온다() throws {
+        // Arrange
+        let encodedData = try JSONEncoder().encode([1, 2, 3])
+        try testDirectoryPaths.forEach {
+            try dataFileManagerSut.set(value: encodedData, forKey: $0)
+        }
+        // Act
+        let loadedDatas = try dataFileManagerSut.getAll(directoryPath: "test")
+        let decodedData = loadedDatas
+            .compactMap{ try? JSONDecoder().decode([Int].self, from: $0) }
+        // Assert
+        XCTAssertEqual(loadedDatas.count, 3)
+        XCTAssertEqual(decodedData.count, 3)
+    }
+
+    func test_getAll에서_디렉토리에_저장한_이미지를_모두_불러온다() throws {
+        // Arrange
+        let image: UIImage = .app
+        try testDirectoryPaths.forEach {
+            try imageFileManagersut.set(value: image.pngData()!, forKey: $0)
+        }
+        // Act
+        let loadedDatas = try imageFileManagersut.getAll(directoryPath: "test")
+        let decodedData = loadedDatas
+            .compactMap{ UIImage(data: $0) }
+        // Assert
+        XCTAssertEqual(loadedDatas.count, 3)
+        XCTAssertEqual(decodedData.count, 3)
+    }
+
+    func test_getAll에서_directoryPath가_아니면_invaildPath_에러를_반환한다() throws {
+        // Arrange
+        let invalidPath: String = "test/test.txt"
+        // Act
+        // Assert
+        XCTAssertThrowsError(try imageFileManagersut.getAll(directoryPath: invalidPath)) { error in
+            XCTAssert(error is FileManagerError)
+            XCTAssertEqual(error as! FileManagerError, FileManagerError.invalidPath)
+        }
+    }
+
+    func test_deleteAll에서_폴더에_파일이_있는_경우_파일과_디렉토리를_삭제한다() throws {
+        // Arrange
+        let encodedData = try JSONEncoder().encode([1, 2, 3])
+        try dataFileManagerSut.set(value: encodedData, forKey: testDirectoryPaths[0])
+        // Act
+        try dataFileManagerSut.deleteAll(directoryPath: testDirectoryPath)
+        // Assert
+        XCTAssertFalse(dataFileManagerSut.fileExists(forKey: testDirectoryPaths[0]))
+        XCTAssertFalse(dataFileManagerSut.fileExists(forKey: testDirectoryPath))
+    }
+
+    func test_deleteAll에서_폴더에_파일이_없는_경우_디렉토리를_삭제한다() throws {
+        // Arrange
+        let encodedData = try JSONEncoder().encode([1, 2, 3])
+        try dataFileManagerSut.set(value: encodedData, forKey: testDirectoryPaths[0])
+        try dataFileManagerSut.delete(forKey: testDirectoryPaths[0])
+        // Act
+        try dataFileManagerSut.deleteAll(directoryPath: testDirectoryPath)
+        // Assert
+        let isExist = dataFileManagerSut.fileExists(forKey: testDirectoryPath, isDirectory: true)
+        XCTAssertFalse(isExist)
+    }
 }

--- a/SniffMeet/SNMSceneTests/WalkLogScene/WalkLogUsecaseTests.swift
+++ b/SniffMeet/SNMSceneTests/WalkLogScene/WalkLogUsecaseTests.swift
@@ -1,0 +1,108 @@
+//
+//  WalkLogUsecaseTests.swift
+//  SNMSceneTests
+//
+//  Created by sole on 2/26/25.
+//
+
+import XCTest
+
+final class WalkLogUsecaseTests: XCTestCase {
+    private var fileManager: SNMFileManager!
+    private var saveWalkLogUsecase: (any SaveWalkLogUseCase)!
+    private var requestWalkLogListUsecase: (any RequestWalkLogListUseCase)!
+    private var testWalkLogs: [WalkLog] = [
+        WalkLog(
+            step: 100,
+            distance: 200,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(300),
+            image: nil
+        ),
+        WalkLog(
+            step: 100,
+            distance: 200,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(100),
+            image: nil
+        ),
+        WalkLog(
+            step: 100,
+            distance: 200,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(200),
+            image: nil
+        )
+    ]
+
+    override func setUp() {
+        fileManager = SNMFileManager(fileType: .data)
+        saveWalkLogUsecase = SaveWalkLogUseCaseImpl(
+            jsonEncoder: JSONEncoder(),
+            fileManager: fileManager
+        )
+        requestWalkLogListUsecase = RequestWalkLogListUseCaseImpl(fileManager: fileManager)
+    }
+
+    override func tearDown() {
+        try? fileManager.deleteAll(directoryPath: Environment.FileManagerKey.walkLog)
+    }
+
+    func test_walkLog_저장에_성공한다() throws {
+        // Arrange
+        let endDate = Date()
+        let walkLog: WalkLog = WalkLog(
+            step: 10,
+            distance: 0,
+            startDate: Date(),
+            endDate: endDate,
+            image: nil
+        )
+        // Act
+        try saveWalkLogUsecase.execute(walkLog: walkLog)
+        // Assert
+        let isExist = fileManager.fileExists(
+            forKey: Environment.FileManagerKey.walkLog,
+            isDirectory: true
+        )
+        XCTAssertTrue(isExist)
+    }
+    func test_산책로그의_파일명을_endDate로_저장한다() throws {
+        // Arrange
+        let endDate = Date()
+        let walkLog: WalkLog = WalkLog(
+            step: 10,
+            distance: 0,
+            startDate: Date(),
+            endDate: endDate,
+            image: nil
+        )
+        // Act
+        try saveWalkLogUsecase.execute(walkLog: walkLog)
+        // Assert
+        let endDateString = endDate.convertDateToISO8601String()
+        let isExist = fileManager.fileExists(
+            forKey: "\(Environment.FileManagerKey.walkLog)/\(endDateString)"
+        )
+        XCTAssert(isExist)
+    }
+    func test_walkLog_폴더에_있는_모든_산책로그를_불러온다() throws {
+        // Arrange
+        try testWalkLogs
+            .forEach{ try saveWalkLogUsecase.execute(walkLog: $0) }
+        // Act
+        let walkLogs = try requestWalkLogListUsecase.execute()
+        // Assert
+        XCTAssertEqual(walkLogs.count, testWalkLogs.count)
+    }
+    func test_walkLog를_불러올때_산책종료시간_최신순으로_불러온다() throws {
+        // Arrange
+        try testWalkLogs
+            .forEach{ try saveWalkLogUsecase.execute(walkLog: $0) }
+        // Act
+        let walkLogs = try requestWalkLogListUsecase.execute()
+        // Assert
+        let comparsion = testWalkLogs.sorted { $0.endDate > $1.endDate }
+        XCTAssertEqual(walkLogs, comparsion)
+    }
+}

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -163,7 +163,6 @@
 		32BD48762D3FF02C0078DA9C /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B612CF433AC0093BEB9 /* Environment.swift */; };
 		32BD48772D3FF02C0078DA9C /* SNMLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD880B592CECE8F90093BEB9 /* SNMLogger.swift */; };
 		32BD48782D3FF02C0078DA9C /* Extension + UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320047DD2CFE9DFB00D08B6D /* Extension + UIApplication.swift */; };
-		32BD48792D3FF02C0078DA9C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		32BD487A2D3FF02C0078DA9C /* Extension + UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE7689E2CF7858D00B5DE88 /* Extension + UIViewController.swift */; };
 		32BD487B2D3FF02C0078DA9C /* AnyJSONSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE768912CF7828600B5DE88 /* AnyJSONSerializable.swift */; };
 		32BD487C2D3FF02C0078DA9C /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE7688F2CF7827900B5DE88 /* AnyDecodable.swift */; };
@@ -274,7 +273,6 @@
 		32BD48F02D40B51E0078DA9C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A03382CD8CF460047B7ED /* AppDelegate.swift */; };
 		32BD48F12D40B51E0078DA9C /* AppRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C328912CE3BEA000D255AB /* AppRouter.swift */; };
 		32BD48F82D40B5450078DA9C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD3A033D2CD8CF460047B7ED /* SceneDelegate.swift */; };
-		32BD48F92D40B5B90078DA9C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		32BD48FB2D40B5E50078DA9C /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 32BD48FA2D40B5E50078DA9C /* OrderedCollections */; };
 		32C539552D64161100CD89DF /* TrackWalkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539542D6415FF00CD89DF /* TrackWalkViewController.swift */; };
 		32C539562D64161100CD89DF /* TrackWalkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539542D6415FF00CD89DF /* TrackWalkViewController.swift */; };
@@ -286,9 +284,6 @@
 		32C539632D64165A00CD89DF /* TrackWalkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539612D64165A00CD89DF /* TrackWalkRouter.swift */; };
 		32C539652D65CB2800CD89DF /* WalkRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539642D65CB2300CD89DF /* WalkRoute.swift */; };
 		32C539662D65CB2800CD89DF /* WalkRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539642D65CB2300CD89DF /* WalkRoute.swift */; };
-		32C5394D2D63245500CD89DF /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C5394C2D63245500CD89DF /* Debug.xcconfig */; };
-		32C5394E2D63245500CD89DF /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C5394C2D63245500CD89DF /* Debug.xcconfig */; };
-		32C5394F2D63245500CD89DF /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C5394C2D63245500CD89DF /* Debug.xcconfig */; };
 		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		993736422CFCACB100E3DD58 /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */; };
@@ -438,6 +433,11 @@
 		FD243D012D62547400971162 /* SNMImageTextToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD243CFF2D62547300971162 /* SNMImageTextToastView.swift */; };
 		FD243D032D62547D00971162 /* SNMImageToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD243D022D62547C00971162 /* SNMImageToastView.swift */; };
 		FD243D042D62547D00971162 /* SNMImageToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD243D022D62547C00971162 /* SNMImageToastView.swift */; };
+		FD259F2C2D6F0AE7007B182D /* SaveWalkLogUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F2B2D6F0AE7007B182D /* SaveWalkLogUseCase.swift */; };
+		FD259F2D2D6F0AE7007B182D /* SaveWalkLogUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F2B2D6F0AE7007B182D /* SaveWalkLogUseCase.swift */; };
+		FD259F2F2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F2E2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift */; };
+		FD259F302D6F0AFA007B182D /* RequestWalkLogListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F2E2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift */; };
+		FD259F342D6F10D1007B182D /* WalkLogUsecaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F322D6F10D1007B182D /* WalkLogUsecaseTests.swift */; };
 		FD2921302D62ACE1009D0762 /* SNMAnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29212F2D62ACDD009D0762 /* SNMAnimationType.swift */; };
 		FD2921312D62ACE1009D0762 /* SNMAnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29212F2D62ACDD009D0762 /* SNMAnimationType.swift */; };
 		FD2921332D632333009D0762 /* DimPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2921322D632330009D0762 /* DimPresentable.swift */; };
@@ -661,7 +661,6 @@
 		32C5395E2D64165900CD89DF /* TrackWalkInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackWalkInteractor.swift; sourceTree = "<group>"; };
 		32C539612D64165A00CD89DF /* TrackWalkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackWalkRouter.swift; sourceTree = "<group>"; };
 		32C539642D65CB2300CD89DF /* WalkRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRoute.swift; sourceTree = "<group>"; };
-		32C5394C2D63245500CD89DF /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserInfoUseCase.swift; sourceTree = "<group>"; };
@@ -772,6 +771,9 @@
 		FD243CFC2D62332000971162 /* SNMToastAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMToastAnimation.swift; sourceTree = "<group>"; };
 		FD243CFF2D62547300971162 /* SNMImageTextToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMImageTextToastView.swift; sourceTree = "<group>"; };
 		FD243D022D62547C00971162 /* SNMImageToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMImageToastView.swift; sourceTree = "<group>"; };
+		FD259F2B2D6F0AE7007B182D /* SaveWalkLogUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveWalkLogUseCase.swift; sourceTree = "<group>"; };
+		FD259F2E2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestWalkLogListUseCase.swift; sourceTree = "<group>"; };
+		FD259F322D6F10D1007B182D /* WalkLogUsecaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WalkLogUsecaseTests.swift; path = SNMSceneTests/WalkLogScene/WalkLogUsecaseTests.swift; sourceTree = SOURCE_ROOT; };
 		FD29212F2D62ACDD009D0762 /* SNMAnimationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMAnimationType.swift; sourceTree = "<group>"; };
 		FD2921322D632330009D0762 /* DimPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimPresentable.swift; sourceTree = "<group>"; };
 		FD331A4C2CF2359D00F39426 /* SNMLineTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMLineTabBar.swift; sourceTree = "<group>"; };
@@ -1021,6 +1023,7 @@
 		320047A42CF9E2A200D08B6D /* RequestUseCase */ = {
 			isa = PBXGroup;
 			children = (
+				FD259F2E2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift */,
 				99E79FA42D556C5600E48552 /* RequestReportUseCase.swift */,
 				FD1152742CFB9F33008955C4 /* CheckFirstLaunchUseCase.swift */,
 				320047A92CFB1C5300D08B6D /* RequestNotiListUseCase.swift */,
@@ -1041,6 +1044,7 @@
 		320047A52CF9E33200D08B6D /* SaveUseCase */ = {
 			isa = PBXGroup;
 			children = (
+				FD259F2B2D6F0AE7007B182D /* SaveWalkLogUseCase.swift */,
 				FD85EBE92D5F3D750017443E /* DeleteNotificationUseCase.swift */,
 				99E79F5A2D5392AF00E48552 /* DeleteMateUseCase.swift */,
 				993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */,
@@ -1208,6 +1212,7 @@
 		32BD48322D3FECAE0078DA9C /* SNMSceneTests */ = {
 			isa = PBXGroup;
 			children = (
+				FD259F312D6F1061007B182D /* WalkLogScene */,
 				32081A662D547F4F00D19235 /* LocalNetwork */,
 				32BD48352D3FECFD0078DA9C /* MateListScene */,
 			);
@@ -1223,16 +1228,6 @@
 				32BD48E32D4085540078DA9C /* MateListPresenterSpy.swift */,
 			);
 			path = MateListScene;
-			sourceTree = "<group>";
-		};
-		99525EBF2D6591FE00B6E17E /* UpdateUseCase */ = {
-			isa = PBXGroup;
-			children = (
-				99525EB92D6563E000B6E17E /* UpdateTimeUseCase.swift */,
-				99525EBC2D65692700B6E17E /* UpdateUserStepUseCase.swift */,
-				FD119F492CED875800BE22BD /* UpdateUserLocationUseCase.swift */,
-			);
-			path = UpdateUseCase;
 			sourceTree = "<group>";
 		};
 		32C539532D6415C400CD89DF /* TrackWalk */ = {
@@ -1477,6 +1472,14 @@
 				FD243CFF2D62547300971162 /* SNMImageTextToastView.swift */,
 			);
 			path = SNMToast;
+			sourceTree = "<group>";
+		};
+		FD259F312D6F1061007B182D /* WalkLogScene */ = {
+			isa = PBXGroup;
+			children = (
+				FD259F322D6F10D1007B182D /* WalkLogUsecaseTests.swift */,
+			);
+			path = WalkLogScene;
 			sourceTree = "<group>";
 		};
 		FD331A4E2CF235B600F39426 /* View */ = {
@@ -2500,7 +2503,6 @@
 				32192B292D41EAF600C876BA /* CGImageCoder.swift in Sources */,
 				32192B282D41E91200C876BA /* TaskSerialQueue.swift in Sources */,
 				32192B272D41E8FD00C876BA /* ImageSampler.swift in Sources */,
-				32BD48F92D40B5B90078DA9C /* (null) in Sources */,
 				32BD48F82D40B5450078DA9C /* SceneDelegate.swift in Sources */,
 				32C5395D2D64165800CD89DF /* TrackWalkViewPresenter.swift in Sources */,
 				32BD48F02D40B51E0078DA9C /* AppDelegate.swift in Sources */,
@@ -2508,6 +2510,7 @@
 				32BD48EF2D40B5130078DA9C /* SessionViewController.swift in Sources */,
 				32BD48ED2D40B4BA0078DA9C /* PushNotificationRequest.swift in Sources */,
 				32BD48EE2D40B4BA0078DA9C /* PushNotificationConfig.swift in Sources */,
+				FD259F2F2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift in Sources */,
 				32BD48EC2D40B4880078DA9C /* Assets.xcassets in Sources */,
 				FD243CFD2D62332500971162 /* SNMToastAnimation.swift in Sources */,
 				FDC8A02E2D66FA190097F00A /* SNMErrorHandler.swift in Sources */,
@@ -2595,7 +2598,6 @@
 				32BD48762D3FF02C0078DA9C /* Environment.swift in Sources */,
 				32BD48772D3FF02C0078DA9C /* SNMLogger.swift in Sources */,
 				32BD48782D3FF02C0078DA9C /* Extension + UIApplication.swift in Sources */,
-				32BD48792D3FF02C0078DA9C /* (null) in Sources */,
 				32BD487A2D3FF02C0078DA9C /* Extension + UIViewController.swift in Sources */,
 				32081B312D5C84EC00D19235 /* OnBoardingPageViewController.swift in Sources */,
 				32081B322D5C84EC00D19235 /* OnBoardingPresenter.swift in Sources */,
@@ -2637,6 +2639,7 @@
 				32BD48972D3FF02C0078DA9C /* ProfileCreateViewController.swift in Sources */,
 				32BD48982D3FF02C0078DA9C /* ProfileCreateInteractor.swift in Sources */,
 				32BD48992D3FF02C0078DA9C /* ProfileInputPresenter.swift in Sources */,
+				FD259F342D6F10D1007B182D /* WalkLogUsecaseTests.swift in Sources */,
 				32BD489A2D3FF02C0078DA9C /* ProfileCreatePresenter.swift in Sources */,
 				32BD489B2D3FF02C0078DA9C /* ProfileInputRouter.swift in Sources */,
 				32BD489C2D3FF02C0078DA9C /* ProfileCreateRouter.swift in Sources */,
@@ -2713,6 +2716,7 @@
 				32BD48D32D3FF02C0078DA9C /* MPCAdvertiser.swift in Sources */,
 				32BD48D42D3FF02C0078DA9C /* MPCBroswer.swift in Sources */,
 				32BD48D52D3FF02C0078DA9C /* SupabaseConfig.swift in Sources */,
+				FD259F2C2D6F0AE7007B182D /* SaveWalkLogUseCase.swift in Sources */,
 				32BD48D62D3FF02C0078DA9C /* SupabaseAuthManager.swift in Sources */,
 				99E79F992D548D9A00E48552 /* ReportMateInteractor.swift in Sources */,
 				99E79FA82D556E1900E48552 /* Report.swift in Sources */,
@@ -2805,9 +2809,11 @@
 				995D94A82CECEF91005A47BF /* RequestMateViewController.swift in Sources */,
 				A2FE77292D521FB200239F05 /* SupabaseSessionManager.swift in Sources */,
 				A2BA1B962CF2606B0080575A /* MateListInteractor.swift in Sources */,
+				FD259F302D6F0AFA007B182D /* RequestWalkLogListUseCase.swift in Sources */,
 				A202A1172CEDD5EF00B98203 /* SupabaseDBRequest.swift in Sources */,
 				FD3A03432CD8CF460047B7ED /* SceneDelegate.swift in Sources */,
 				99FA4E792CE0FBBF00553C2E /* ProfileInputViewController.swift in Sources */,
+				FD259F2D2D6F0AE7007B182D /* SaveWalkLogUseCase.swift in Sources */,
 				3200448D2CEC878300D08B6D /* RespondWalkViewController.swift in Sources */,
 				A28D4F582CFED0CB00A79543 /* AddMateButton.swift in Sources */,
 				FD331A932CF3463200F39426 /* NotificationCell.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
@@ -25,6 +25,7 @@ enum Environment {
     
     enum FileManagerKey {
         static let profileImage: String = "profile"
+        static let walkLog: String = "walkLog"
     }
 
     enum LocalNetworkKey {

--- a/SniffMeet/SniffMeet/Source/Core/Persistence/DataStoragable.swift
+++ b/SniffMeet/SniffMeet/Source/Core/Persistence/DataStoragable.swift
@@ -20,6 +20,9 @@ enum FileType {
 
 protocol FileManagable: DataStorageManagable where StoredType == Data {
     var fileType: FileType { get } // managing할 파일의 타입을 지정합니다.
+    /// 파일 확장자가 포함되지 않은 directoryPath만을 입력으로 받습니다.
+    func getAll(directoryPath: String) throws -> [StoredType]
+    func deleteAll(directoryPath: String) throws
 }
 
 protocol TokenManagable: DataStorageManagable where StoredType == String {}

--- a/SniffMeet/SniffMeet/Source/Core/Persistence/SNMFileManager.swift
+++ b/SniffMeet/SniffMeet/Source/Core/Persistence/SNMFileManager.swift
@@ -8,33 +8,39 @@ import Foundation
 
 struct SNMFileManager: FileManagable {
     var fileType: FileType
-    
+
     private var fileManager: FileManager { FileManager.default }
     private var documentsDir: URL? {
         fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
     }
     private func fullURL(for fileName: String) -> URL? {
-        guard fileType == .data else {
-            return documentsDir?.appendingPathComponent(fileName)
+        switch fileType {
+        case .data:
+            documentsDir?.appendingPathComponent(fileName, conformingTo: .data)
+        case .image:
+            documentsDir?.appendingPathComponent(fileName, conformingTo: .jpeg)
         }
-        return documentsDir?.appendingPathComponent(fileName, conformingTo: .jpeg)
-       }
-    
-    func fileExists(forKey path: String) -> Bool {
-        guard let fileURL = fullURL(for: path) else { return false }
+    }
+    private func fullDirectoryURL(for path: String) -> URL? {
+        documentsDir?.appendingPathComponent(path)
+    }
+
+    func fileExists(forKey path: String, isDirectory: Bool = false) -> Bool {
+        guard let fileURL = isDirectory ?
+                fullDirectoryURL(for: path) : fullURL(for: path) else { return false }
         if #available(iOS 16.0, *) {
             return fileManager.fileExists(atPath: fileURL.path())
         } else {
             return fileManager.fileExists(atPath: fileURL.path)
         }
     }
-    
+
     /// key 값은 Environment.FileManagerKey를 이용하시면 됩니다.
     func get(forKey: String) throws -> Data {
         guard let fileURL = fullURL(for: forKey) else {
             throw FileManagerError.directoryNotFound
         }
-        
+
         guard fileManager.fileExists(atPath: fileURL.path) else {
             throw FileManagerError.fileNotFound
         }
@@ -45,14 +51,60 @@ struct SNMFileManager: FileManagable {
         guard let fileURL = fullURL(for: forKey) else {
             throw FileManagerError.directoryNotFound
         }
-        try data.write(to: fileURL)
+        try createDirectoryIfNeeded(url: fileURL)
+        do {
+            try data.write(to: fileURL)
+        } catch {
+            throw FileManagerError.writeError
+        }
     }
-    
+
+    private func createDirectoryIfNeeded(url: URL) throws {
+        var directoryURL: URL = url
+        directoryURL.deleteLastPathComponent()
+        try fileManager.createDirectory(
+            atPath: directoryURL.path,
+            withIntermediateDirectories: true
+        )
+    }
+
     func delete(forKey: String) throws {
         guard let fileURL = fullURL(for: forKey) else {
             throw FileManagerError.directoryNotFound
         }
-        try fileManager.removeItem(at: fileURL)
+        do {
+            try fileManager.removeItem(at: fileURL)
+        } catch {
+            throw FileManagerError.deleteError
+        }
+    }
+    
+    func getAll(directoryPath: String) throws -> [Data] {
+        guard let fileURL = fullDirectoryURL(for: directoryPath) else {
+            throw FileManagerError.directoryNotFound
+        }
+        guard fileURL.pathExtension.isEmpty else {
+            throw FileManagerError.invalidPath
+        }
+        let contentsURLs = try fileManager.contentsOfDirectory(
+            at: fileURL,
+            includingPropertiesForKeys: nil
+        )
+        return contentsURLs.compactMap { try? Data(contentsOf: $0) }
+    }
+
+    func deleteAll(directoryPath: String) throws {
+        guard let fileURL = fullDirectoryURL(for: directoryPath) else {
+            throw FileManagerError.directoryNotFound
+        }
+        guard fileURL.pathExtension.isEmpty else {
+            throw FileManagerError.invalidPath
+        }
+        do {
+            try fileManager.removeItem(at: fileURL)
+        } catch {
+            throw FileManagerError.deleteError
+        }
     }
 }
 
@@ -64,6 +116,7 @@ enum FileManagerError: LocalizedError {
     case noDeleteObject
     case writeError
     case deleteError
+    case invalidPath
 
     var errorDescription: String? {
         switch self {
@@ -74,6 +127,7 @@ enum FileManagerError: LocalizedError {
         case .noDeleteObject: "삭제할 대상을 찾을 수 없습니다."
         case .writeError: "파일 쓰기 에러"
         case .deleteError: "파일 삭제 에러"
+        case .invalidPath: "유효하지 않은 경로"
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Entity/WalkLog.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/WalkLog.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct WalkLog {
+struct WalkLog: Codable, Equatable {
     let step: Int
     let distance: Double
     let startDate: Date

--- a/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestWalkLogListUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RequestUseCase/RequestWalkLogListUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  RequestWalkLogListUseCase.swift
+//  SniffMeet
+//
+//  Created by sole on 2/26/25.
+//
+
+import Foundation
+
+protocol RequestWalkLogListUseCase {
+    func execute() throws -> [WalkLog]
+}
+
+struct RequestWalkLogListUseCaseImpl: RequestWalkLogListUseCase {
+    private let jsonDecoder: JSONDecoder
+    private let fileManager: any FileManagable
+
+    init(
+        jsonDecoder: JSONDecoder = JSONDecoder(),
+        fileManager: any FileManagable
+    ) {
+        self.jsonDecoder = jsonDecoder
+        self.fileManager = fileManager
+    }
+
+    func execute() throws -> [WalkLog] {
+        try fileManager.getAll(directoryPath: Environment.FileManagerKey.walkLog)
+            .compactMap { try? jsonDecoder.decode(WalkLog.self, from: $0) }
+            .sorted{ $0.endDate > $1.endDate } // 최신순 정렬
+    }
+}

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveWalkLogUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveWalkLogUseCase.swift
@@ -1,0 +1,38 @@
+//
+//  SaveWalkLogUseCase.swift
+//  SniffMeet
+//
+//  Created by sole on 2/26/25.
+//
+
+import Foundation
+
+protocol SaveWalkLogUseCase {
+    func execute(walkLog: WalkLog) throws
+}
+
+struct SaveWalkLogUseCaseImpl: SaveWalkLogUseCase {
+    private let jsonEncoder: JSONEncoder
+    private let fileManager: any FileManagable
+
+    init(
+        jsonEncoder: JSONEncoder = JSONEncoder(),
+        fileManager: any FileManagable
+    ) {
+        self.jsonEncoder = jsonEncoder
+        self.fileManager = fileManager
+    }
+
+    func execute(walkLog: WalkLog) throws {
+        let timestamp = walkLog.endDate.convertDateToISO8601String() // 저장한 시각
+        do {
+            let walkLogData = try jsonEncoder.encode(walkLog)
+            try fileManager.set(
+                value: walkLogData,
+                forKey: "\(Environment.FileManagerKey.walkLog)/\(timestamp)"
+            )
+        } catch {
+            throw SNMError(level: .logOnly, error: error)
+        }
+    }
+}


### PR DESCRIPTION
### 🔖  Issue Number

close #33 
close #34 

### 📙 작업 내역

### FileManager getAll / deleteAll 메서드 추가 
- FileType에 따라 파일 확장자를 붙이는 방식을 변경했습니다. 
- 주어진 directoryPath 내 파일을 모두 불러오는 getAll 메서드를 구현했습니다.
- 주어진 directoryPath 내 파일과 폴더를 모두 삭제하는 deleteAll 메서드를 구현했습니다. 

### WalkLog Usecase 구현 
- 산책 로그 저장 Usecase를 구현했습니다. 
- 산책 로그를 최신순으로 불러오는 Usecase를 구현했습니다. 

### 유닛 테스트 
- FileManager 

![image](https://github.com/user-attachments/assets/46ee4bb9-4da8-4d18-a291-02aa9678ec1f)


- WalkLogUsecase

![image](https://github.com/user-attachments/assets/e9a7b210-7034-4f77-be47-9483cc203143)


### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 

기존에는 FileManager에서 FileType이 .image인 경우 파일 확장자를 붙이지 않았습니다.  
이번 PR에서 FileType이 .image로 주어지는 경우 무조건 파일 이름에 .jpeg을 붙이도록 변경되었습니다. 
경로변경으로 인해 프로필이 정상적으로 로드되지 않는 현상이 발생합니다. 
앱 삭제 후 재설치 하시면 정상적으로 동작합니다. 

<img src="https://github.com/user-attachments/assets/d0a9a2a7-d0c5-4cf4-84ab-f5df5b3256ca" height=300>
