### PR TITLE
[feat] 산책 로그 저장 유즈케이스 연결

### DIFF
--- a/SniffMeet/SniffMeet/Source/Common/Util/SNMErrorHandler.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Util/SNMErrorHandler.swift
@@ -49,7 +49,8 @@ struct SNMErrorHandler: ErrorHandler {
     }
     /// SNMError가 아닌 에러는 자동으로 logOnly로 매핑합니다. 에러가 발생한 Context를 기록합니다.
     func handle(error: any Error, file: String = #file, function: String = #function) {
-        let snmError = SNMError(level: .logOnly, error: error, file: file, function: function)
+        let snmError = error is SNMError ? error :
+        SNMError(level: .logOnly, error: error, file: file, function: function)
         self.handle(snmError)
     }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
@@ -12,7 +12,8 @@ protocol TrackWalkInteractable: AnyObject {
     var presenter: TrackWalkInteractorOutput? { get set }
 
     func startTracking()
-    func stopTracking() -> WalkLog?
+    func stopTracking(snapshotImageData: Data?) -> WalkLog?
+    func saveWalkLog(walkLog: WalkLog) throws
 }
 
 final class TrackWalkInteractor: TrackWalkInteractable {
@@ -20,6 +21,7 @@ final class TrackWalkInteractor: TrackWalkInteractable {
     private let updateTimeUseCase: any UpdateTimeUseCase
     private let updateUserStepUseCase: any UpdateUserStepUseCase
     private let updateUserLocationUseCase: any UpdateUserLocationUseCase
+    private let saveWalkLogUsecase: any SaveWalkLogUseCase
 
     private var startDate: Date?
     private var endDate: Date?
@@ -33,11 +35,13 @@ final class TrackWalkInteractor: TrackWalkInteractable {
     init(
         updateTimeUseCase: any UpdateTimeUseCase,
         updateUserStepUseCase: any UpdateUserStepUseCase,
-        updateUserLocationUseCase: any UpdateUserLocationUseCase
+        updateUserLocationUseCase: any UpdateUserLocationUseCase,
+        saveWalkLogUsecase: any SaveWalkLogUseCase
     ){
         self.updateTimeUseCase = updateTimeUseCase
         self.updateUserStepUseCase = updateUserStepUseCase
         self.updateUserLocationUseCase = updateUserLocationUseCase
+        self.saveWalkLogUsecase = saveWalkLogUsecase
     }
 
     func startTracking() {
@@ -97,7 +101,7 @@ final class TrackWalkInteractor: TrackWalkInteractable {
         SNMLogger.log("이동 거리: \(totalDistance) meters")
     }
 
-    func stopTracking() -> WalkLog? {
+    func stopTracking(snapshotImageData: Data?) -> WalkLog? {
         endDate = Date()
         updateTimeUseCase.cancel()
         updateUserStepUseCase.cancel()
@@ -110,7 +114,11 @@ final class TrackWalkInteractor: TrackWalkInteractable {
             distance: totalDistance,
             startDate: startDate,
             endDate: endDate,
-            image: nil
+            image: snapshotImageData
         )
+    }
+
+    func saveWalkLog(walkLog: WalkLog) throws {
+        try saveWalkLogUsecase.execute(walkLog: walkLog)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
@@ -12,7 +12,7 @@ protocol TrackWalkPresentable: AnyObject {
     var router: (any TrackWalkRoutable)? { get set }
 
     func startTracking()
-    func endTracking()
+    func endTracking(snapshotImageData: Data?)
 }
 protocol TrackWalkInteractorOutput: AnyObject {
     func updateWalkRecord(_ record: WalkRecord)
@@ -23,13 +23,50 @@ final class TrackWalkViewPresenter: TrackWalkPresentable {
     weak var view: (any TrackWalkViewable)?
     var interactor: (any TrackWalkInteractable)?
     var router: (any TrackWalkRoutable)?
+    private var endTrackingErrorHandler: SNMErrorHandler
+
+    init(
+        view: (any TrackWalkViewable)? = nil,
+        interactor: (any TrackWalkInteractable)? = nil,
+        router: (any TrackWalkRoutable)? = nil,
+        endTrackingErrorHandler: SNMErrorHandler = SNMErrorHandler()
+    ) {
+        self.view = view
+        self.interactor = interactor
+        self.router = router
+        self.endTrackingErrorHandler = endTrackingErrorHandler
+        configureErrorHandlers()
+    }
 
     func startTracking() {
         interactor?.startTracking()
     }
-    func endTracking() {
-        // TODO: -  인터랙터에 저장 요청하는 로직
-        
+    func endTracking(snapshotImageData: Data?) {
+        Task { @MainActor [weak self] in
+            guard let walkLog = self?.interactor?.stopTracking(
+                snapshotImageData: snapshotImageData
+            ) else { return }
+
+            do {
+                try self?.interactor?.saveWalkLog(walkLog: walkLog)
+                try await self?.view?.showRouteResult(with: snapshotImageData)
+                guard let view = self?.view else { return }
+                self?.router?.pop(from: view)
+            } catch {
+                self?.endTrackingErrorHandler.handle(error: error)
+            }
+        }
+    }
+    private func configureErrorHandlers() {
+        endTrackingErrorHandler.configure { [weak self] level in
+            switch level {
+            case .notifyUser:
+                guard let view = self?.view else { break }
+                self?.router?.presentFailedToSaveTrackingAlert(from: view)
+            default:
+                break
+            }
+        }
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Router/TrackWalkRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Router/TrackWalkRouter.swift
@@ -11,14 +11,29 @@ protocol TrackWalkRoutable: AnyObject, Routable {
     var presenter: (any TrackWalkPresentable)? { get set }
     
     func pop(from view: TrackWalkViewable)
+    func presentFailedToSaveTrackingAlert(from view: any TrackWalkViewable)
 }
 
 final class TrackWalkRouter: TrackWalkRoutable {
     weak var presenter: (any TrackWalkPresentable)?
     
-    func pop(from view: TrackWalkViewable) {
+    func pop(from view: any TrackWalkViewable) {
+        guard let view = view as? UIViewController else { return }
         Task { @MainActor in
-            pop(from: view as! UIViewController, animated: true)
+            pop(from: view, animated: true)
+        }
+    }
+    func presentFailedToSaveTrackingAlert(from view: any TrackWalkViewable) {
+        guard let view = view as? UIViewController else { return }
+        let failedAlertViewController = UIAlertController(
+            title: "산책 기록 저장 실패",
+            message: "산책 기록을 저장하는데 실패했습니다. 다시 시도해주세요.",
+            preferredStyle: .alert
+        )
+        let confirmAction = UIAlertAction(title: "확인", style: .default)
+        failedAlertViewController.addAction(confirmAction)
+        Task { @MainActor [weak self] in
+            self?.present(from: view, with: failedAlertViewController, animated: true)
         }
     }
 }
@@ -38,7 +53,9 @@ extension TrackWalkRouter: TrackWalkModuleBuildable {
         let interactor: TrackWalkInteractable = TrackWalkInteractor(
             updateTimeUseCase: updateTimeUseCase,
             updateUserStepUseCase: updateUserStepUseCase,
-            updateUserLocationUseCase: updateUserLocationUseCase)
+            updateUserLocationUseCase: updateUserLocationUseCase,
+            saveWalkLogUsecase: SaveWalkLogUseCaseImpl(fileManager: SNMFileManager(fileType: .data))
+        )
         let router: TrackWalkRoutable & TrackWalkModuleBuildable = TrackWalkRouter()
         
         view.presenter = presenter

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
@@ -13,13 +13,17 @@ protocol TrackWalkViewable: AnyObject {
     
     func updateRouteLine(with location: WalkRoute)
     func updateWalkRecord(record: WalkRecord)
+    func showRouteResult(with mapImageData: Data?) async throws
 }
 
 final class TrackWalkViewController: BaseViewController {
     var presenter: (any TrackWalkPresentable)?
     private var cancellables: Set<AnyCancellable> = []
-    private var isStarted: Bool = false
-    
+    private var isStarted: Bool = false {
+        didSet {
+            updateRecordButton()
+        }
+    }
     private let mapView: MKMapView = {
         let mapView: MKMapView = MKMapView()
         mapView.showsUserLocation = true
@@ -206,11 +210,14 @@ final class TrackWalkViewController: BaseViewController {
                     self?.presenter?.startTracking()
                     return
                 }
-                Task { @MainActor in
-                    await self?.stopRecordWalk()
-                }
+                self?.stopRecordWalk()
             }
             .store(in: &cancellables)
+    }
+
+    private func updateRecordButton() {
+        trackingButton.setTitle(isStarted ? "중지" : "시작", for: .normal)
+        trackingButton.backgroundColor = isStarted ? SNMColor.warningRed : SNMColor.mainNavy
     }
 }
 
@@ -225,34 +232,29 @@ extension TrackWalkViewController: TrackWalkViewable {
         distanceValueLabel.text = record.distance.description
         numberOfStepsValueLabel.text = record.stepCount.description
     }
+
+    func showRouteResult(with mapImageData: Data?) async throws {
+        mapView.isHidden = true
+        trackingButton.isHidden = true
+        if let mapImageData {
+            routeMapImageView.image = UIImage(data: mapImageData)
+        }
+        routeMapImageView.isHidden = false
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+    }
 }
 
 private extension TrackWalkViewController {
-    func showRouteResult(with mapImage: UIImage) {
-        mapView.isHidden = true
-        routeMapImageView.image = mapImage
-        routeMapImageView.isHidden = false
-    }
-    
-    func stopRecordWalk() async {
+    func stopRecordWalk() {
         isStarted = false
         trackingButton.isEnabled = false
-        guard let mapImage = screenshot(at: mapView) else {
-            presenter?.endTracking()
-            return
-        }
-        showRouteResult(with: mapImage)
-        do {
-            try await Task.sleep(nanoseconds: 3000000000)
-        } catch {
-            SNMLogger.error("TrackWalkViewController: \(error.localizedDescription)")
-        }
-        presenter?.endTracking()
+        let mapImageData = screenshot(at: mapView)
+        presenter?.endTracking(snapshotImageData: mapImageData)
     }
     
-    func screenshot(at view: UIView) -> UIImage? {
+    func screenshot(at view: UIView) -> Data? {
         let renderer = UIGraphicsImageRenderer(size: view.bounds.size)
-        return renderer.image { context in
+        return renderer.pngData { imageData in
             view.drawHierarchy(in: view.bounds, afterScreenUpdates: true)
         }
     }

--- a/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveWalkLogUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/SaveUseCase/SaveWalkLogUseCase.swift
@@ -32,7 +32,7 @@ struct SaveWalkLogUseCaseImpl: SaveWalkLogUseCase {
                 forKey: "\(Environment.FileManagerKey.walkLog)/\(timestamp)"
             )
         } catch {
-            throw SNMError(level: .logOnly, error: error)
+            throw SNMError(level: .notifyUser, error: error)
         }
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

close #45 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
>

### SaveWalkLogUsecase와 TrackWalkModule과 연결 
- snapshot 반환 타입 UIImage?에서 Data?로 변경
- 산책 결과를 3초 동안 보여줄 때 산책 시작/종료 버튼을 hidden하도록 변경 
- 산책 로그 저장 실패시 Alert을 띄우는 로직 구현 

### 시뮬레이션 

- snapshot이 실패했을 때 

![RocketSim_Recording_iPhone_16_Plus_6 7_2025-02-27_06 59 21](https://github.com/user-attachments/assets/016c79b8-0cad-452f-996f-0d7af4fe2ebb)

- snapshot이 성공했을 때 

![RocketSim_Recording_iPhone_16_Plus_6 7_2025-02-27_07 00 38](https://github.com/user-attachments/assets/dc96ee9d-4d8a-454e-bc82-1aa46fc54451)

- 산책 로그 저장에 실패했을 때 

![RocketSim_Recording_iPhone_16_Plus_6 7_2025-02-27_07 01 57](https://github.com/user-attachments/assets/c1940989-4e00-48b1-abca-667df0bd74af)
