### PR TITLE
[feat] 산책 로그 뷰와 유즈케이스 연결

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -438,6 +438,12 @@
 		FD259F2F2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F2E2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift */; };
 		FD259F302D6F0AFA007B182D /* RequestWalkLogListUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F2E2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift */; };
 		FD259F342D6F10D1007B182D /* WalkLogUsecaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F322D6F10D1007B182D /* WalkLogUsecaseTests.swift */; };
+		FD259F422D6FD2D0007B182D /* WalkLogListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F412D6FD2C9007B182D /* WalkLogListPresenter.swift */; };
+		FD259F432D6FD2D0007B182D /* WalkLogListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F412D6FD2C9007B182D /* WalkLogListPresenter.swift */; };
+		FD259F452D6FD2E8007B182D /* WalkLogListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F442D6FD2E1007B182D /* WalkLogListInteractor.swift */; };
+		FD259F462D6FD2E8007B182D /* WalkLogListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F442D6FD2E1007B182D /* WalkLogListInteractor.swift */; };
+		FD259F482D6FD2FC007B182D /* WalkLogListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F472D6FD2F7007B182D /* WalkLogListRouter.swift */; };
+		FD259F492D6FD2FC007B182D /* WalkLogListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD259F472D6FD2F7007B182D /* WalkLogListRouter.swift */; };
 		FD2921302D62ACE1009D0762 /* SNMAnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29212F2D62ACDD009D0762 /* SNMAnimationType.swift */; };
 		FD2921312D62ACE1009D0762 /* SNMAnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD29212F2D62ACDD009D0762 /* SNMAnimationType.swift */; };
 		FD2921332D632333009D0762 /* DimPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2921322D632330009D0762 /* DimPresentable.swift */; };
@@ -774,6 +780,9 @@
 		FD259F2B2D6F0AE7007B182D /* SaveWalkLogUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveWalkLogUseCase.swift; sourceTree = "<group>"; };
 		FD259F2E2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestWalkLogListUseCase.swift; sourceTree = "<group>"; };
 		FD259F322D6F10D1007B182D /* WalkLogUsecaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WalkLogUsecaseTests.swift; path = SNMSceneTests/WalkLogScene/WalkLogUsecaseTests.swift; sourceTree = SOURCE_ROOT; };
+		FD259F412D6FD2C9007B182D /* WalkLogListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkLogListPresenter.swift; sourceTree = "<group>"; };
+		FD259F442D6FD2E1007B182D /* WalkLogListInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkLogListInteractor.swift; sourceTree = "<group>"; };
+		FD259F472D6FD2F7007B182D /* WalkLogListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkLogListRouter.swift; sourceTree = "<group>"; };
 		FD29212F2D62ACDD009D0762 /* SNMAnimationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMAnimationType.swift; sourceTree = "<group>"; };
 		FD2921322D632330009D0762 /* DimPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DimPresentable.swift; sourceTree = "<group>"; };
 		FD331A4C2CF2359D00F39426 /* SNMLineTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNMLineTabBar.swift; sourceTree = "<group>"; };
@@ -1778,6 +1787,7 @@
 		FDA4914D2CDA65EE00A36FB0 /* Interactor */ = {
 			isa = PBXGroup;
 			children = (
+				FD259F442D6FD2E1007B182D /* WalkLogListInteractor.swift */,
 			);
 			path = Interactor;
 			sourceTree = "<group>";
@@ -1785,20 +1795,15 @@
 		FDA4914E2CDA65F400A36FB0 /* Presenter */ = {
 			isa = PBXGroup;
 			children = (
+				FD259F412D6FD2C9007B182D /* WalkLogListPresenter.swift */,
 			);
 			path = Presenter;
-			sourceTree = "<group>";
-		};
-		FDA4914F2CDA65F900A36FB0 /* Entity */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Entity;
 			sourceTree = "<group>";
 		};
 		FDA491502CDA65FF00A36FB0 /* Router */ = {
 			isa = PBXGroup;
 			children = (
+				FD259F472D6FD2F7007B182D /* WalkLogListRouter.swift */,
 			);
 			path = Router;
 			sourceTree = "<group>";
@@ -1862,7 +1867,6 @@
 				FD331A4E2CF235B600F39426 /* View */,
 				FDA4914D2CDA65EE00A36FB0 /* Interactor */,
 				FDA4914E2CDA65F400A36FB0 /* Presenter */,
-				FDA4914F2CDA65F900A36FB0 /* Entity */,
 				FDA491502CDA65FF00A36FB0 /* Router */,
 			);
 			path = WalkLogList;
@@ -2510,6 +2514,7 @@
 				32BD48EF2D40B5130078DA9C /* SessionViewController.swift in Sources */,
 				32BD48ED2D40B4BA0078DA9C /* PushNotificationRequest.swift in Sources */,
 				32BD48EE2D40B4BA0078DA9C /* PushNotificationConfig.swift in Sources */,
+				FD259F482D6FD2FC007B182D /* WalkLogListRouter.swift in Sources */,
 				FD259F2F2D6F0AFA007B182D /* RequestWalkLogListUseCase.swift in Sources */,
 				32BD48EC2D40B4880078DA9C /* Assets.xcassets in Sources */,
 				FD243CFD2D62332500971162 /* SNMToastAnimation.swift in Sources */,
@@ -2584,6 +2589,7 @@
 				32BD486C2D3FF02C0078DA9C /* AnyEncodable.swift in Sources */,
 				32BD486D2D3FF02C0078DA9C /* MockURLProtocol.swift in Sources */,
 				32BD486E2D3FF02C0078DA9C /* MockRequest.swift in Sources */,
+				FD259F452D6FD2E8007B182D /* WalkLogListInteractor.swift in Sources */,
 				32BD486F2D3FF02C0078DA9C /* DataStoragable.swift in Sources */,
 				FD243CFA2D621FC600971162 /* SNMProgressView.swift in Sources */,
 				32BD48702D3FF02C0078DA9C /* CacheManager.swift in Sources */,
@@ -2604,6 +2610,7 @@
 				32081B332D5C84EC00D19235 /* OnBoardingInteractor.swift in Sources */,
 				32081B342D5C84EC00D19235 /* OnBoardingRouter.swift in Sources */,
 				32081B352D5C84EC00D19235 /* OnBoardingViewController.swift in Sources */,
+				FD259F422D6FD2D0007B182D /* WalkLogListPresenter.swift in Sources */,
 				32BD487B2D3FF02C0078DA9C /* AnyJSONSerializable.swift in Sources */,
 				32BD487C2D3FF02C0078DA9C /* AnyDecodable.swift in Sources */,
 				32BD487D2D3FF02C0078DA9C /* Extension + Date.swift in Sources */,
@@ -2859,6 +2866,7 @@
 				FD331A582CF23CEC00F39426 /* WalkLogCell.swift in Sources */,
 				FD01D8FA2D40ACAF00AD4940 /* Extension + Array.swift in Sources */,
 				FD5134172CEB738D002E76F3 /* UIControl + Publisher.swift in Sources */,
+				FD259F432D6FD2D0007B182D /* WalkLogListPresenter.swift in Sources */,
 				320047BE2CFDE37300D08B6D /* WalkRequestDTO.swift in Sources */,
 				320044852CEC836400D08B6D /* PaddingLabel.swift in Sources */,
 				A2BD49FF2CF7712800AC72A7 /* Keyword.swift in Sources */,
@@ -2955,8 +2963,10 @@
 				FDBFA99F2CE1E50C00AA9220 /* SNMFont.swift in Sources */,
 				FD119F4E2CED87C200BE22BD /* SelectLocationPresenter.swift in Sources */,
 				32C539562D64161100CD89DF /* TrackWalkViewController.swift in Sources */,
+				FD259F462D6FD2E8007B182D /* WalkLogListInteractor.swift in Sources */,
 				FD243D042D62547D00971162 /* SNMImageToastView.swift in Sources */,
 				99E79FAC2D556E8600E48552 /* ReportDTO.swift in Sources */,
+				FD259F492D6FD2FC007B182D /* WalkLogListRouter.swift in Sources */,
 				FD5134192CEB7ADE002E76F3 /* HomeRouter.swift in Sources */,
 				FD51341D2CEB7AF0002E76F3 /* HomeInteractor.swift in Sources */,
 				3200453F2CF5A8B800D08B6D /* CalculateTimeLimitUseCase.swift in Sources */,

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Presenter/TrackWalkViewPresenter.swift
@@ -13,6 +13,7 @@ protocol TrackWalkPresentable: AnyObject {
 
     func startTracking()
     func endTracking()
+    func didTapDismissButton()
 }
 protocol TrackWalkInteractorOutput: AnyObject {
     func updateWalkRecord(_ record: WalkRecord)
@@ -30,6 +31,10 @@ final class TrackWalkViewPresenter: TrackWalkPresentable {
     func endTracking() {
         // TODO: -  인터랙터에 저장 요청하는 로직
         
+    }
+    func didTapDismissButton() {
+        guard let view else { return }
+        router?.pop(from: view)
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/View/TrackWalkViewController.swift
@@ -50,11 +50,28 @@ final class TrackWalkViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         trackingButton.layoutIfNeeded()
         trackingButton.makeViewCircular()
     }
-    
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        tabBarController?.tabBar.isHidden = false
+        tabBarController?.tabBar.backgroundColor = .white
+    }
+
     override func configureAttributes() {
+        tabBarController?.tabBar.isHidden = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "chevron.left"),
+            style: .plain,
+            target: self,
+            action: #selector(didTapDismissButton)
+        )
+        navigationItem.leftBarButtonItem?.tintColor = SNMColor.mainNavy
+        navigationItem.title = Context.navigationTitle
+
         [timeTitleLabel, numberOfStepsTitleLabel, distanceTitleLabel].forEach {
             $0.textColor = SNMColor.subGray3
             $0.font = SNMFont.callout
@@ -212,6 +229,10 @@ final class TrackWalkViewController: BaseViewController {
             }
             .store(in: &cancellables)
     }
+
+    @objc private func didTapDismissButton() {
+        presenter?.didTapDismissButton()
+    }
 }
 
 extension TrackWalkViewController: TrackWalkViewable {
@@ -276,6 +297,7 @@ extension TrackWalkViewController: MKMapViewDelegate {
 
 private extension TrackWalkViewController {
     enum Context {
+        static let navigationTitle = "산책하기"
         static let trackButtonStartTitle = "시작"
         static let trackButtonStopTitle = "종료"
         static let timeTitle = "시간"

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Interactor/WalkLogListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Interactor/WalkLogListInteractor.swift
@@ -5,10 +5,35 @@
 //  Created by sole on 2/27/25.
 //
 
+import Foundation
+
 protocol WalkLogListInteractable: AnyObject {
     var presenter: (any WalkLogListPresentable)? { get }
+
+    func fetchUserInfo() throws -> (name: String, profileImageData: Data?)
+    func fetchWalkLogList() throws -> [WalkLog]
 }
 
 final class WalkLogListInteractor: WalkLogListInteractable {
     weak var presenter: (any WalkLogListPresentable)?
+    private let loadUserInfoUsecase: any LoadUserInfoUseCase
+    private let requestWalkLogListUsecase: any RequestWalkLogListUseCase
+
+    init(
+        presenter: (any WalkLogListPresentable)? = nil,
+        loadUserInfoUsecase: any LoadUserInfoUseCase,
+        requestWalkLogListUsecase: any RequestWalkLogListUseCase
+    ) {
+        self.presenter = presenter
+        self.loadUserInfoUsecase = loadUserInfoUsecase
+        self.requestWalkLogListUsecase = requestWalkLogListUsecase
+    }
+
+    func fetchUserInfo() throws -> (name: String, profileImageData: Data?) {
+        let userInfo = try loadUserInfoUsecase.execute()
+        return (userInfo.name, userInfo.profileImage)
+    }
+    func fetchWalkLogList() throws -> [WalkLog] {
+        try requestWalkLogListUsecase.execute()
+    }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Interactor/WalkLogListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Interactor/WalkLogListInteractor.swift
@@ -1,0 +1,14 @@
+//
+//  WalkLogListInteractor.swift
+//  SniffMeet
+//
+//  Created by sole on 2/27/25.
+//
+
+protocol WalkLogListInteractable: AnyObject {
+    var presenter: (any WalkLogListPresentable)? { get }
+}
+
+final class WalkLogListInteractor: WalkLogListInteractable {
+    weak var presenter: (any WalkLogListPresentable)?
+}

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Presenter/WalkLogListPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Presenter/WalkLogListPresenter.swift
@@ -5,14 +5,61 @@
 //  Created by sole on 2/27/25.
 //
 
+import Combine
+import Foundation
+
 protocol WalkLogListPresentable: AnyObject {
     var view: (any WalkLogListViewable)? { get }
     var interactor: (any WalkLogListInteractable)? { get }
     var router: (any WalkLogListRoutable)? { get }
+    var output: (any WalkLogListPresenterOutput) { get }
+
+    func viewDidLoad()
 }
 
 final class WalkLogListPresenter: WalkLogListPresentable {
     weak var view: (any WalkLogListViewable)?
     var interactor: (any WalkLogListInteractable)?
     var router: (any WalkLogListRoutable)?
+    var output: any WalkLogListPresenterOutput
+
+    init(
+        view: (any WalkLogListViewable)? = nil,
+        interactor: (any WalkLogListInteractable)? = nil,
+        router: (any WalkLogListRoutable)? = nil,
+        output: any WalkLogListPresenterOutput = DefaultWalkLogListPresenterOutput(
+            walkLogList: [],
+            name: "후추추",
+            profileImageData: nil
+        )
+    ) {
+        self.view = view
+        self.interactor = interactor
+        self.router = router
+        self.output = output
+    }
+
+    func viewDidLoad() {
+        do {
+            let (name, profileImageData) = try interactor?.fetchUserInfo() ?? ("", nil)
+            output.name = name
+            output.profileImageData = profileImageData
+            let walkLogList = try interactor?.fetchWalkLogList()
+            output.walkLogList = walkLogList ?? []
+        } catch {
+            SNMLogger.log(error.localizedDescription)
+        }
+    }
+}
+
+protocol WalkLogListPresenterOutput {
+    var walkLogList: [WalkLog] { get set }
+    var name: String { get set }
+    var profileImageData: Data? { get set }
+}
+
+struct DefaultWalkLogListPresenterOutput: WalkLogListPresenterOutput {
+    var walkLogList: [WalkLog]
+    var name: String
+    var profileImageData: Data?
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Presenter/WalkLogListPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Presenter/WalkLogListPresenter.swift
@@ -15,6 +15,7 @@ protocol WalkLogListPresentable: AnyObject {
     var output: (any WalkLogListPresenterOutput) { get }
 
     func viewDidLoad()
+    func didTapAddWalkLogButton()
 }
 
 final class WalkLogListPresenter: WalkLogListPresentable {
@@ -49,6 +50,10 @@ final class WalkLogListPresenter: WalkLogListPresentable {
         } catch {
             SNMLogger.log(error.localizedDescription)
         }
+    }
+    func didTapAddWalkLogButton() {
+        guard let view else { return }
+        router?.showTrackWalkView(view: view)
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Presenter/WalkLogListPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Presenter/WalkLogListPresenter.swift
@@ -1,0 +1,18 @@
+//
+//  WalkLogListPresenter.swift
+//  SniffMeet
+//
+//  Created by sole on 2/27/25.
+//
+
+protocol WalkLogListPresentable: AnyObject {
+    var view: (any WalkLogListViewable)? { get }
+    var interactor: (any WalkLogListInteractable)? { get }
+    var router: (any WalkLogListRoutable)? { get }
+}
+
+final class WalkLogListPresenter: WalkLogListPresentable {
+    weak var view: (any WalkLogListViewable)?
+    var interactor: (any WalkLogListInteractable)?
+    var router: (any WalkLogListRoutable)?
+}

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Router/WalkLogListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Router/WalkLogListRouter.swift
@@ -23,7 +23,15 @@ extension WalkLogListRouter: WalkLogListModuleBuildable {
     static func buildWalkLogListModule() -> UIViewController {
         let view = WalkLogListViewController()
         let presenter = WalkLogListPresenter()
-        let interactor = WalkLogListInteractor()
+        let interactor = WalkLogListInteractor(
+            loadUserInfoUsecase: LoadUserInfoUseCaseImpl(
+                dataLoadable: LocalDataManager(),
+                imageManageable: SNMFileManager(fileType: .image)
+            ),
+            requestWalkLogListUsecase: RequestWalkLogListUseCaseImpl(
+                fileManager: SNMFileManager(fileType: .data)
+            )
+        )
         let router = WalkLogListRouter()
 
         view.presenter = presenter

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Router/WalkLogListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Router/WalkLogListRouter.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol WalkLogListRoutable: AnyObject, Routable {
-
+    func showTrackWalkView(view: any WalkLogListViewable)
 }
 
 protocol WalkLogListModuleBuildable {
@@ -16,7 +16,10 @@ protocol WalkLogListModuleBuildable {
 }
 
 final class WalkLogListRouter: WalkLogListRoutable {
-
+    func showTrackWalkView(view: any WalkLogListViewable) {
+        guard let view = view as? UIViewController else { return }
+        push(from: view, to: TrackWalkRouter.create(), animated: true)
+    }
 }
 
 extension WalkLogListRouter: WalkLogListModuleBuildable {

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Router/WalkLogListRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/Router/WalkLogListRouter.swift
@@ -1,0 +1,37 @@
+//
+//  WalkLogListRouter.swift
+//  SniffMeet
+//
+//  Created by sole on 2/27/25.
+//
+
+import UIKit
+
+protocol WalkLogListRoutable: AnyObject, Routable {
+
+}
+
+protocol WalkLogListModuleBuildable {
+    static func buildWalkLogListModule() -> UIViewController
+}
+
+final class WalkLogListRouter: WalkLogListRoutable {
+
+}
+
+extension WalkLogListRouter: WalkLogListModuleBuildable {
+    static func buildWalkLogListModule() -> UIViewController {
+        let view = WalkLogListViewController()
+        let presenter = WalkLogListPresenter()
+        let interactor = WalkLogListInteractor()
+        let router = WalkLogListRouter()
+
+        view.presenter = presenter
+        presenter.view = view
+        presenter.interactor = interactor
+        presenter.router = router
+        interactor.presenter = presenter
+
+        return view
+    }
+}

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogCell.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogCell.swift
@@ -12,7 +12,7 @@ final class WalkLogCell: UITableViewCell {
 
     private let profileStackView: UIStackView = UIStackView()
     private let nickNameLabel: UILabel = UILabel()
-    private let dateAndLocationLabel: UILabel = UILabel()
+    private let dateLabel: UILabel = UILabel()
 
     private let walkLogStackView: UIStackView = UIStackView()
 
@@ -24,21 +24,17 @@ final class WalkLogCell: UITableViewCell {
     private let stepTitleLabel: UILabel = UILabel()
     private let stepLabel: UILabel = UILabel()
 
-    private let timeStackView: UIStackView = UIStackView()
-    private let timeTitleLabel: UILabel = UILabel()
-    private let timeLabel: UILabel = UILabel()
+    private let durationStackView: UIStackView = UIStackView()
+    private let durationTitleLabel: UILabel = UILabel()
+    private let durationLabel: UILabel = UILabel()
 
     private let walkLogImageView: UIImageView = UIImageView(frame: .zero)
 
-    init(
-        dogInfo: DogProfileDTO,
-        walkLog: WalkLog,
+    override init(
         style: UITableViewCell.CellStyle,
         reuseIdentifier: String?
     ) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        configureCell(dogInfo: dogInfo)
-        configureCell(walkLog: walkLog)
         configureAttributes()
         configureHierarchy()
         configureConstraints()
@@ -52,19 +48,19 @@ final class WalkLogCell: UITableViewCell {
     private func configureAttributes() {
         profileImageView.backgroundColor = SNMColor.subGray1
         profileImageView.image = UIImage(resource: .imagePlaceholder)
-        profileImageView.layer.cornerRadius = Context.profileImageSize / 2
-        profileImageView.clipsToBounds = true
+        profileImageView.layer.masksToBounds = true
+        profileImageView.layer.cornerRadius = Layout.profileImageSize / 2
 
         nickNameLabel.font = SNMFont.headline
 
-        dateAndLocationLabel.font = SNMFont.caption2
-        dateAndLocationLabel.textColor = SNMColor.text2
+        dateLabel.font = SNMFont.caption2
+        dateLabel.textColor = SNMColor.text2
 
         walkLogStackView.spacing = 30
         profileStackView.axis = .vertical
         distanceStackView.axis = .vertical
         stepStackView.axis = .vertical
-        timeStackView.axis = .vertical
+        durationStackView.axis = .vertical
 
         distanceTitleLabel.text = Context.distanceLabelTitle
         distanceTitleLabel.textAlignment = .center
@@ -80,18 +76,18 @@ final class WalkLogCell: UITableViewCell {
         stepLabel.font = SNMFont.caption2
         stepLabel.textAlignment = .center
 
-        timeTitleLabel.text = Context.timeLabelTitle
-        timeTitleLabel.textAlignment = .center
-        timeTitleLabel.textColor = SNMColor.text2
-        timeTitleLabel.font = SNMFont.caption2
-        timeLabel.font = SNMFont.caption2
-        timeLabel.textAlignment = .center
+        durationTitleLabel.text = Context.timeLabelTitle
+        durationTitleLabel.textAlignment = .center
+        durationTitleLabel.textColor = SNMColor.text2
+        durationTitleLabel.font = SNMFont.caption2
+        durationLabel.font = SNMFont.caption2
+        durationLabel.textAlignment = .center
 
         walkLogImageView.image = UIImage(resource: .imagePlaceholder)
     }
     private func configureHierarchy() {
         [nickNameLabel,
-         dateAndLocationLabel].forEach {
+         dateLabel].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             profileStackView.addArrangedSubview($0)
         }
@@ -105,14 +101,14 @@ final class WalkLogCell: UITableViewCell {
             $0.translatesAutoresizingMaskIntoConstraints = false
             stepStackView.addArrangedSubview($0)
         }
-        [timeTitleLabel,
-         timeLabel].forEach {
+        [durationTitleLabel,
+         durationLabel].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
-            timeStackView.addArrangedSubview($0)
+            durationStackView.addArrangedSubview($0)
         }
         [distanceStackView,
          stepStackView,
-         timeStackView].forEach {
+         durationStackView].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             walkLogStackView.addArrangedSubview($0)
         }
@@ -128,10 +124,10 @@ final class WalkLogCell: UITableViewCell {
     private func configureConstraints() {
         NSLayoutConstraint.activate([
             profileImageView.widthAnchor.constraint(
-                equalToConstant: Context.profileImageSize
+                equalToConstant: Layout.profileImageSize
             ),
             profileImageView.heightAnchor.constraint(
-                equalToConstant: Context.profileImageSize
+                equalToConstant: Layout.profileImageSize
             ),
             profileImageView.topAnchor.constraint(
                 equalTo: contentView.topAnchor,
@@ -155,7 +151,7 @@ final class WalkLogCell: UITableViewCell {
             stepStackView.heightAnchor.constraint(
                 equalToConstant: SNMFont.caption.lineHeight * 2
             ),
-            timeStackView.heightAnchor.constraint(
+            durationStackView.heightAnchor.constraint(
                 equalToConstant: SNMFont.caption.lineHeight * 2
             ),
 
@@ -177,20 +173,26 @@ final class WalkLogCell: UITableViewCell {
             ),
             walkLogImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             walkLogImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            walkLogImageView.heightAnchor.constraint(equalToConstant: 246)
+            walkLogImageView.heightAnchor.constraint(equalToConstant: Layout.profileImageViewHeight)
         ])
     }
-    func configureCell(walkLog: WalkLog) {
-        distanceLabel.text = "\(walkLog.distance)"
-        timeLabel.text = "\(walkLog.duration)"
-        stepLabel.text = "\(100)"
-        dateAndLocationLabel.text = "부천시 100213213"
+
+    func configureWalkLogSection(
+        date: String,
+        distance: String,
+        step: String,
+        duration: String,
+        image: UIImage?
+    ) {
+        dateLabel.text = date
+        distanceLabel.text = distance
+        stepLabel.text = step
+        durationLabel.text = duration
+        walkLogImageView.image = image ?? .imagePlaceholder
     }
-    func configureCell(dogInfo: DogProfileDTO) {
-        if let profileImage = dogInfo.profileImage {
-            profileImageView.image = UIImage(data: profileImage)
-        }
-        nickNameLabel.text = dogInfo.name
+    func configureProfileSection(profileImage: UIImage?, name: String) {
+        profileImageView.image = profileImage ?? .imagePlaceholder
+        nickNameLabel.text = name
     }
 }
 
@@ -198,13 +200,17 @@ extension WalkLogCell {
     static let identifier: String = String(describing: WalkLogCell.self)
 }
 
-// MARK: - WalkLogCell+Context
+// MARK: - WalkLogCell+Constant
 
 private extension WalkLogCell {
     enum Context {
         static let distanceLabelTitle: String = "거리"
         static let stepLabelTitle: String = "걸음 수"
         static let timeLabelTitle: String = "시간"
+    }
+
+    enum Layout {
         static let profileImageSize: CGFloat = 58
+        static let profileImageViewHeight: CGFloat = 246
     }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
@@ -50,24 +50,8 @@ extension WalkLogListViewController: UITableViewDataSource {
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
-        // FIXME: 실제 데이터로 변경 필요
-        WalkLogCell(
-            dogInfo: .init(
-            id: UUID(uuidString: "") ?? DogProfileDTO.example.id,
-            name: "후추추",
-            keywords: [],
-            profileImage: nil
-            ),
-            walkLog: .init(
-                step: 100,
-                distance: 1002.2,
-                startDate: .now,
-                endDate: .now,
-                image: nil
-            ),
-            style: .default,
-            reuseIdentifier: WalkLogCell.identifier
-        )
+        let cell = WalkLogCell(style: .default, reuseIdentifier: WalkLogCell.identifier)
+        return cell
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
@@ -15,10 +15,16 @@ final class WalkLogListViewController: BaseViewController, WalkLogListViewable {
     var presenter: (any WalkLogListPresentable)?
     private let walkLogTableView: UITableView = UITableView()
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        presenter?.viewDidLoad()
+    }
+
     override func configureAttributes() {
         walkLogTableView.dataSource = self
         walkLogTableView.delegate = self
         walkLogTableView.separatorInset = .zero
+        walkLogTableView.allowsSelection = false
     }
     override func configureHierachy() {
         [walkLogTableView].forEach {
@@ -34,6 +40,23 @@ final class WalkLogListViewController: BaseViewController, WalkLogListViewable {
             walkLogTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
+
+    private func distanceLabelString(_ meters: Double) -> String {
+        String(format: "%.2f km", meters / 1000)
+    }
+    private func dateLabelString(_ date: Date) -> String {
+        let dateFormatter: DateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy년 MM월 dd일"
+        return dateFormatter.string(from: date)
+    }
+    private func durationLabelString(_ timeInterval: TimeInterval) -> String {
+        let totalSeconds = Int(timeInterval)
+        let hours = totalSeconds / (60 * 60)
+        let minutes = (totalSeconds / 60) % 60
+        let seconds = Int(totalSeconds) % 60
+
+        return hours > 0 ? "\(hours)시간 \(minutes)분" : "\(minutes)분 \(seconds)초"
+    }
 }
 
 //MARK: - WalkLogListViewController+UITableView DataSource, Delegate
@@ -43,14 +66,34 @@ extension WalkLogListViewController: UITableViewDataSource {
         _ tableView: UITableView,
         numberOfRowsInSection section: Int
     ) -> Int {
-        3
+        presenter?.output.walkLogList.count ?? 0
     }
     
     func tableView(
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
-        let cell = WalkLogCell(style: .default, reuseIdentifier: WalkLogCell.identifier)
+        let cell: WalkLogCell = walkLogTableView.dequeueReusableCell(
+            withIdentifier: WalkLogCell.identifier
+        ) as? WalkLogCell ?? WalkLogCell(style: .default, reuseIdentifier: WalkLogCell.identifier)
+        let walkLogs: [WalkLog] = presenter?.output.walkLogList ?? []
+
+        cell.configureWalkLogSection(
+            date: dateLabelString(walkLogs[indexPath.row].endDate),
+            distance: distanceLabelString(walkLogs[indexPath.row].distance),
+            step: "\(walkLogs[indexPath.row].step) 걸음",
+            duration: durationLabelString(walkLogs[indexPath.row].duration),
+            image: UIImage(
+                data: walkLogs[indexPath.row].image ?? Data()
+            )
+        )
+        cell.configureProfileSection(
+            profileImage: UIImage(
+                data: presenter?.output.profileImageData ?? Data()
+            ),
+            name: presenter?.output.name ?? "후추추"
+        )
+
         return cell
     }
 }
@@ -61,11 +104,5 @@ extension WalkLogListViewController: UITableViewDelegate {
         heightForRowAt indexPath: IndexPath
     ) -> CGFloat {
         393
-    }
-    func tableView(
-        _ tableView: UITableView,
-        didSelectRowAt indexPath: IndexPath
-    ) {
-        tableView.deselectRow(at: indexPath, animated: true)
     }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
@@ -7,7 +7,12 @@
 
 import UIKit
 
-final class WalkLogListViewController: BaseViewController {
+protocol WalkLogListViewable: AnyObject {
+    var presenter: (any WalkLogListPresentable)? { get }
+}
+
+final class WalkLogListViewController: BaseViewController, WalkLogListViewable {
+    var presenter: (any WalkLogListPresentable)?
     private let walkLogTableView: UITableView = UITableView()
 
     override func configureAttributes() {

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
@@ -5,6 +5,7 @@
 //  Created by sole on 11/24/24.
 //
 
+import Combine
 import UIKit
 
 protocol WalkLogListViewable: AnyObject {
@@ -13,7 +14,9 @@ protocol WalkLogListViewable: AnyObject {
 
 final class WalkLogListViewController: BaseViewController, WalkLogListViewable {
     var presenter: (any WalkLogListPresentable)?
+    private var cancellabels: Set<AnyCancellable> = []
     private let walkLogTableView: UITableView = UITableView()
+    private let addWalkLogButton: UIButton = UIButton()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,9 +28,22 @@ final class WalkLogListViewController: BaseViewController, WalkLogListViewable {
         walkLogTableView.delegate = self
         walkLogTableView.separatorInset = .zero
         walkLogTableView.allowsSelection = false
+
+        let plusImage = UIImage(
+            systemName: "plus",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: LayoutConstant.iconSize)
+        )
+        addWalkLogButton.setImage(plusImage, for: .normal)
+        addWalkLogButton.tintColor = .white
+        addWalkLogButton.backgroundColor = SNMColor.mainBrown
+        addWalkLogButton.layer.cornerRadius = Layout.addButtonSize / 2
+        addWalkLogButton.layer.shadowColor = UIColor.black.cgColor
+        addWalkLogButton.layer.shadowOffset = CGSize(width: 0, height: 4)
+        addWalkLogButton.layer.shadowOpacity = 0.25
     }
     override func configureHierachy() {
-        [walkLogTableView].forEach {
+        [walkLogTableView,
+         addWalkLogButton].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview($0)
         }
@@ -37,19 +53,43 @@ final class WalkLogListViewController: BaseViewController, WalkLogListViewable {
             walkLogTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             walkLogTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             walkLogTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            walkLogTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            walkLogTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            addWalkLogButton.widthAnchor.constraint(equalToConstant: Layout.addButtonSize),
+            addWalkLogButton.heightAnchor.constraint(equalToConstant: Layout.addButtonSize),
+            addWalkLogButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -LayoutConstant.regularVerticalPadding
+            ),
+            addWalkLogButton.trailingAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                constant: -LayoutConstant.regularVerticalPadding
+            ),
         ])
     }
+    override func bind() {
+        addWalkLogButton.publisher(event: .touchUpInside)
+            .sink { [weak self] _ in
+                self?.presenter?.didTapAddWalkLogButton()
+            }
+            .store(in: &cancellabels)
+    }
+}
 
-    private func distanceLabelString(_ meters: Double) -> String {
+private extension WalkLogListViewController {
+    enum Layout {
+        static let addButtonSize: CGFloat = 66
+    }
+
+    func distanceLabelString(_ meters: Double) -> String {
         String(format: "%.2f km", meters / 1000)
     }
-    private func dateLabelString(_ date: Date) -> String {
+    func dateLabelString(_ date: Date) -> String {
         let dateFormatter: DateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 MM월 dd일"
         return dateFormatter.string(from: date)
     }
-    private func durationLabelString(_ timeInterval: TimeInterval) -> String {
+    func durationLabelString(_ timeInterval: TimeInterval) -> String {
         let totalSeconds = Int(timeInterval)
         let hours = totalSeconds / (60 * 60)
         let minutes = (totalSeconds / 60) % 60

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogPageViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogPageViewController.swift
@@ -18,7 +18,7 @@ final class WalkLogPageViewController: BaseViewController {
     )
     // TODO: 실제 ViewController로 대체 필요
     private var dataSource: [UIViewController] = [
-        WalkLogListViewController(),
+        WalkLogListRouter.buildWalkLogListModule(),
         HomeViewController()
     ]
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogPageViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogPageViewController.swift
@@ -17,7 +17,7 @@ final class WalkLogPageViewController: BaseViewController {
         navigationOrientation: .horizontal
     )
     // TODO: 실제 ViewController로 대체 필요
-    private var dataSource: [UIViewController] = [
+    private var subViewControllers: [UIViewController] = [
         WalkLogListRouter.buildWalkLogListModule(),
         HomeViewController()
     ]
@@ -29,7 +29,7 @@ final class WalkLogPageViewController: BaseViewController {
         pageViewController.delegate = self
         pageViewController.dataSource = self
         pageViewController.setViewControllers(
-            [dataSource[currentIndex]],
+            [subViewControllers[currentIndex]],
             direction: .forward,
             animated: true
         )
@@ -47,7 +47,7 @@ final class WalkLogPageViewController: BaseViewController {
         NSLayoutConstraint.activate([
             lineTabBar.topAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.topAnchor,
-                constant: 8
+                constant: LayoutConstant.xsmallVerticalPadding
             ),
             lineTabBar.heightAnchor.constraint(
                 equalToConstant: lineTabBar.intrinsicContentSize.height
@@ -77,11 +77,11 @@ final class WalkLogPageViewController: BaseViewController {
 
     private func updatePageViewController(index: Int) {
         guard currentIndex != index,
-              index < dataSource.count else { return }
+              index < subViewControllers.count else { return }
         let direction: UIPageViewController.NavigationDirection = currentIndex < index ?
             .forward : .reverse
         pageViewController.setViewControllers(
-            [dataSource[index]],
+            [subViewControllers[index]],
             direction: direction,
             animated: true
         )
@@ -108,8 +108,8 @@ extension WalkLogPageViewController: UIPageViewControllerDelegate {
      ) {
        guard
         let viewController = pageViewController.viewControllers?.first,
-        let viewIndex = dataSource.firstIndex(of: viewController) else { return }
-         lineTabBar.selectTab(index: viewIndex)
+        let viewIndex = subViewControllers.firstIndex(of: viewController) else { return }
+        lineTabBar.selectTab(index: viewIndex)
      }
 }
 
@@ -118,16 +118,16 @@ extension WalkLogPageViewController: UIPageViewControllerDataSource {
         _ pageViewController: UIPageViewController,
         viewControllerBefore viewController: UIViewController
     ) -> UIViewController? {
-        guard let index = dataSource.firstIndex(of: viewController),
+        guard let index = subViewControllers.firstIndex(of: viewController),
               index - 1 > -1 else { return nil }
-        return dataSource[index - 1]
+        return subViewControllers[index - 1]
     }
     func pageViewController(
         _ pageViewController: UIPageViewController,
         viewControllerAfter viewController: UIViewController
     ) -> UIViewController? {
-        guard let index = dataSource.firstIndex(of: viewController),
-              index + 1 < dataSource.count else { return nil }
-        return dataSource[index + 1]
+        guard let index = subViewControllers.firstIndex(of: viewController),
+              index + 1 < subViewControllers.count else { return nil }
+        return subViewControllers[index + 1]
     }
 }


### PR DESCRIPTION
### 🔖  Issue Number

close #58 

### 📙 작업 내역

### 산책 로그 뷰와 유즈케이스 연결 
- VIPER 모듈 생성 
- 산책 로그 Cell 구성방식 변경 (WalkLog 의존성 제거)

### 산책 로그 뷰와 산책 기록 뷰 화면전환 로직 구현 
- 산책 기록하기(+버튼) 플로팅 버튼 구현 
- routing 로직 구현 
- 산책 기록 뷰에서 TabBar Item을 보이지 않도록 수정 
- 산책 기록 뷰에서 custom chevron button 적용

### 시뮬레이션 

- 산책 로그 뷰 

![image](https://github.com/user-attachments/assets/e3375f27-e3ae-4626-8c0e-3daff74ebe28)

- 화면 이동 

![RocketSim_Recording_iPhone_16_Plus_6 7_2025-02-27_21 08 21](https://github.com/user-attachments/assets/49d0fa9b-ac87-4cfe-bf47-31ca9eeda402)


### 📝 PR 특이사항 

