### PR TITLE
[fix/feat] ni없는 프로필 드랍 기능 디버깅 및 기능 추가 

### DIFF
--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -284,6 +284,15 @@
 		32C539632D64165A00CD89DF /* TrackWalkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539612D64165A00CD89DF /* TrackWalkRouter.swift */; };
 		32C539652D65CB2800CD89DF /* WalkRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539642D65CB2300CD89DF /* WalkRoute.swift */; };
 		32C539662D65CB2800CD89DF /* WalkRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C539642D65CB2300CD89DF /* WalkRoute.swift */; };
+		32C539F92D7804A700CD89DF /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539F82D7804A700CD89DF /* Debug.xcconfig */; };
+		32C539FA2D7804A700CD89DF /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539F82D7804A700CD89DF /* Debug.xcconfig */; };
+		32C539FB2D7804A700CD89DF /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539F82D7804A700CD89DF /* Debug.xcconfig */; };
+		32C539FD2D7804DC00CD89DF /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */; };
+		32C539FE2D7804DC00CD89DF /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */; };
+		32C539FF2D7804DC00CD89DF /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */; };
+		32C53A012D78324D00CD89DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 32C53A002D78324D00CD89DF /* GoogleService-Info.plist */; };
+		32C53A022D78324D00CD89DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 32C53A002D78324D00CD89DF /* GoogleService-Info.plist */; };
+		32C53A032D78324D00CD89DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 32C53A002D78324D00CD89DF /* GoogleService-Info.plist */; };
 		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		993736422CFCACB100E3DD58 /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */; };
@@ -661,6 +670,9 @@
 		32C5395E2D64165900CD89DF /* TrackWalkInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackWalkInteractor.swift; sourceTree = "<group>"; };
 		32C539612D64165A00CD89DF /* TrackWalkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackWalkRouter.swift; sourceTree = "<group>"; };
 		32C539642D65CB2300CD89DF /* WalkRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRoute.swift; sourceTree = "<group>"; };
+		32C539F82D7804A700CD89DF /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		32C539FC2D7804DC00CD89DF /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		32C53A002D78324D00CD89DF /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserInfoUseCase.swift; sourceTree = "<group>"; };
@@ -802,8 +814,6 @@
 		FD51341C2CEB7AEC002E76F3 /* HomeInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInteractor.swift; sourceTree = "<group>"; };
 		FD51341E2CEB7AF6002E76F3 /* LoadUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadUserInfoUseCase.swift; sourceTree = "<group>"; };
 		FD5134222CEC2BDB002E76F3 /* Routable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routable.swift; sourceTree = "<group>"; };
-		FD5946652D6CF0BC006FF9C3 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
-		FD5946662D6CF0CB006FF9C3 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		FD69B1B22CE3BC68009D71DC /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		FD69B1B42CE3BC79009D71DC /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		FD69B1BA2CE3BCDC009D71DC /* SNMPersistenceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SNMPersistenceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1521,8 +1531,6 @@
 				32BD48322D3FECAE0078DA9C /* SNMSceneTests */,
 				A24B1F352D3C338B0012B860 /* SNMUtilityTests */,
 				FD3A03212CD8CDE50047B7ED /* Products */,
-				FD5946652D6CF0BC006FF9C3 /* Debug.xcconfig */,
-				FD5946662D6CF0CB006FF9C3 /* Release.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1617,6 +1625,9 @@
 		FDA4912A2CD9FE3500A36FB0 /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				32C539FC2D7804DC00CD89DF /* Release.xcconfig */,
+				32C539F82D7804A700CD89DF /* Debug.xcconfig */,
+				32C53A002D78324D00CD89DF /* GoogleService-Info.plist */,
 				99A5A1B22CFFE544002F1D2D /* ProfileDrop.gif */,
 				FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */,
 				FD3A033A2CD8CF460047B7ED /* Info.plist */,
@@ -2447,6 +2458,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32C539FF2D7804DC00CD89DF /* Release.xcconfig in Resources */,
+				32C539FB2D7804A700CD89DF /* Debug.xcconfig in Resources */,
+				32C53A032D78324D00CD89DF /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2470,8 +2484,11 @@
 			files = (
 				A288A63D2CDC595000D11C34 /* (null) in Resources */,
 				99A5A1B32CFFE545002F1D2D /* ProfileDrop.gif in Resources */,
+				32C539FD2D7804DC00CD89DF /* Release.xcconfig in Resources */,
 				FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */,
+				32C539FA2D7804A700CD89DF /* Debug.xcconfig in Resources */,
 				FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */,
+				32C53A022D78324D00CD89DF /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2479,8 +2496,11 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32C539FE2D7804DC00CD89DF /* Release.xcconfig in Resources */,
 				3200453B2CF442D500D08B6D /* Assets.xcassets in Resources */,
+				32C53A012D78324D00CD89DF /* GoogleService-Info.plist in Resources */,
 				99A5A1B42CFFE545002F1D2D /* ProfileDrop.gif in Resources */,
+				32C539F92D7804A700CD89DF /* Debug.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3305,6 +3325,7 @@
 		};
 		FD3A03352CD8CDE60047B7ED /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -3351,7 +3372,7 @@
 		};
 		FD3A03362CD8CDE60047B7ED /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FD5946652D6CF0BC006FF9C3 /* Debug.xcconfig */;
+			baseConfigurationReference = 32C539F82D7804A700CD89DF /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -3415,7 +3436,7 @@
 		};
 		FD3A03372CD8CDE60047B7ED /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FD5946662D6CF0CB006FF9C3 /* Release.xcconfig */;
+			baseConfigurationReference = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -3461,6 +3482,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[arch=*]" = 18.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -3580,7 +3602,7 @@
 				32BD482F2D3FEC9D0078DA9C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		A24B1F2D2D3C32960012B860 /* Build configuration list for PBXNativeTarget "SNMUtilityTests" */ = {
 			isa = XCConfigurationList;
@@ -3589,7 +3611,7 @@
 				A24B1F2C2D3C32960012B860 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		FD331A6B2CF33C6700F39426 /* Build configuration list for PBXNativeTarget "SupabaseTests" */ = {
 			isa = XCConfigurationList;
@@ -3598,7 +3620,7 @@
 				FD331A6D2CF33C6700F39426 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		FD3A031B2CD8CDE50047B7ED /* Build configuration list for PBXProject "SniffMeet" */ = {
 			isa = XCConfigurationList;
@@ -3607,7 +3629,7 @@
 				FD3A03372CD8CDE60047B7ED /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		FD3A03332CD8CDE60047B7ED /* Build configuration list for PBXNativeTarget "SniffMeet" */ = {
 			isa = XCConfigurationList;
@@ -3616,7 +3638,7 @@
 				FD3A03352CD8CDE60047B7ED /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		FD69B1C02CE3BCDC009D71DC /* Build configuration list for PBXNativeTarget "SNMPersistenceTests" */ = {
 			isa = XCConfigurationList;
@@ -3625,7 +3647,7 @@
 				FD69B1C22CE3BCDC009D71DC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		FDCD02C42CE9172600B627D8 /* Build configuration list for PBXNativeTarget "SNMNetworkTests" */ = {
 			isa = XCConfigurationList;
@@ -3634,7 +3656,7 @@
 				FDCD02C32CE9172600B627D8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 

--- a/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
+++ b/SniffMeet/SniffMeet.xcodeproj/project.pbxproj
@@ -290,9 +290,6 @@
 		32C539FD2D7804DC00CD89DF /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */; };
 		32C539FE2D7804DC00CD89DF /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */; };
 		32C539FF2D7804DC00CD89DF /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 32C539FC2D7804DC00CD89DF /* Release.xcconfig */; };
-		32C53A012D78324D00CD89DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 32C53A002D78324D00CD89DF /* GoogleService-Info.plist */; };
-		32C53A022D78324D00CD89DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 32C53A002D78324D00CD89DF /* GoogleService-Info.plist */; };
-		32C53A032D78324D00CD89DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 32C53A002D78324D00CD89DF /* GoogleService-Info.plist */; };
 		9919104F2CFF552C008F86D6 /* OnBoardingPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */; };
 		9937361D2CF80D6600E3DD58 /* RequestUserInfoRemoteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */; };
 		993736422CFCACB100E3DD58 /* UpdateUserInfoUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */; };
@@ -672,7 +669,6 @@
 		32C539642D65CB2300CD89DF /* WalkRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRoute.swift; sourceTree = "<group>"; };
 		32C539F82D7804A700CD89DF /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		32C539FC2D7804DC00CD89DF /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
-		32C53A002D78324D00CD89DF /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		9919104E2CFF5526008F86D6 /* OnBoardingPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingPage.swift; sourceTree = "<group>"; };
 		9937361C2CF80D5200E3DD58 /* RequestUserInfoRemoteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestUserInfoRemoteUseCase.swift; sourceTree = "<group>"; };
 		993736412CFCACA800E3DD58 /* UpdateUserInfoUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserInfoUseCase.swift; sourceTree = "<group>"; };
@@ -1627,7 +1623,6 @@
 			children = (
 				32C539FC2D7804DC00CD89DF /* Release.xcconfig */,
 				32C539F82D7804A700CD89DF /* Debug.xcconfig */,
-				32C53A002D78324D00CD89DF /* GoogleService-Info.plist */,
 				99A5A1B22CFFE544002F1D2D /* ProfileDrop.gif */,
 				FD3A033C2CD8CF460047B7ED /* LaunchScreen.storyboard */,
 				FD3A033A2CD8CF460047B7ED /* Info.plist */,
@@ -2460,7 +2455,6 @@
 			files = (
 				32C539FF2D7804DC00CD89DF /* Release.xcconfig in Resources */,
 				32C539FB2D7804A700CD89DF /* Debug.xcconfig in Resources */,
-				32C53A032D78324D00CD89DF /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2488,7 +2482,6 @@
 				FD3A033F2CD8CF460047B7ED /* Assets.xcassets in Resources */,
 				32C539FA2D7804A700CD89DF /* Debug.xcconfig in Resources */,
 				FD3A03412CD8CF460047B7ED /* LaunchScreen.storyboard in Resources */,
-				32C53A022D78324D00CD89DF /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2498,7 +2491,6 @@
 			files = (
 				32C539FE2D7804DC00CD89DF /* Release.xcconfig in Resources */,
 				3200453B2CF442D500D08B6D /* Assets.xcassets in Resources */,
-				32C53A012D78324D00CD89DF /* GoogleService-Info.plist in Resources */,
 				99A5A1B42CFFE545002F1D2D /* ProfileDrop.gif in Resources */,
 				32C539F92D7804A700CD89DF /* Debug.xcconfig in Resources */,
 			);

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/Interactor/ProfileDropInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/Interactor/ProfileDropInteractor.swift
@@ -67,6 +67,9 @@ final class ProfileDropInteractor: ProfileDropInteractable {
             $0.receive(on: RunLoop.main)
             .sink {[weak self] (state) in
                 self?.handleConnectionState(state: state)
+                Task { @MainActor [weak self] in
+                    self?.presenter?.closeBrowserView()
+                }
             }
             .store(in: &cancellables)
         }

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/Presenter/ProfileDropPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/Presenter/ProfileDropPresenter.swift
@@ -17,15 +17,16 @@ protocol ProfileDropPresentable: AnyObject {
     func showBrowserView()
     func quitProfileDrop()
     func didTapHelp()
+    func didCloseTheView()
 }
 
 protocol ProfileDropInteractorOutput: AnyObject {
-    func didCloseTheView()
     func didConnectNISession()
     func failToConnectNISession()
     func showConnectionState(to state: ConnectionState)
     func receiveProfileData(_ data: DogDTO)
     func updateDeviceInfo()
+    func closeBrowserView()
 }
 
 final class ProfileDropPresenter: ProfileDropPresentable {
@@ -52,10 +53,20 @@ final class ProfileDropPresenter: ProfileDropPresentable {
     func startTargetedProfileDrop() {
         interactor?.tryNearByProfileDrop()
     }
+    func didCloseTheView() {
+        guard let view else { return }
+        router?.dismissView(view: view)
+    }
     func showBrowserView() {
         if let view = self.view,
            let browserViewController = interactor?.mcBrowserViewController() as? AnyObject {
             router?.presentMCBrowserView(from: view, to: browserViewController)
+        }
+    }
+    func closeBrowserView() {
+        if let view = self.view,
+           let browserViewController = interactor?.mcBrowserViewController() as? AnyObject {
+            router?.dismissMCBrowserView(view: browserViewController)
         }
     }
     func quitProfileDrop() {
@@ -71,8 +82,6 @@ final class ProfileDropPresenter: ProfileDropPresentable {
 }
 
 extension ProfileDropPresenter: ProfileDropInteractorOutput {
-    func didCloseTheView() {
-    }
     func didConnectNISession() {
         view?.changeState(to: .successNISession)
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/Router/ProfileDropRouter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/Router/ProfileDropRouter.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol ProfileDropRoutable: AnyObject, Routable {
     var presenter: (any ProfileDropPresentable)? { get set }
     func presentMCBrowserView (from profileDropView: any ProfileDropViewable, to mcBrowserView: AnyObject)
+    func dismissMCBrowserView (view: AnyObject)
     func dismissView(view: any ProfileDropViewable)
     func showMateRequestView(profileDropView: any ProfileDropViewable, data: DogDTO)
     func showHelpView(profileDropView: any ProfileDropViewable)
@@ -29,10 +30,16 @@ final class ProfileDropRouter: ProfileDropRoutable {
         present(from: profileDropView, with: mcBrowserViewController, animated: true)
     }
     
+    func dismissMCBrowserView (view: AnyObject) {
+        guard let mcBrowserViewController = view as? UIViewController
+        else { return }
+        dismiss(from: mcBrowserViewController, animated: true)
+    }
+    
     func dismissView(view: any ProfileDropViewable) {
         if let view = view as? UIViewController {
             Task { @MainActor in
-                dismiss(from: view, animated: true)
+                pop(from: view, animated: true)
             }
         }
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/View/ConnectionState.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/View/ConnectionState.swift
@@ -11,6 +11,7 @@ enum ConnectionState {
     case successMPCSession
     case failure
     case cannotFindPeer
+    case finished
 
     var description: String {
         switch self {
@@ -24,6 +25,8 @@ enum ConnectionState {
             return "연결 실패, 다시 시도해보세요!"
         case .cannotFindPeer:
             return "주위 산책 친구를 찾을 수 없어요. 다시 시도해보세요!"
+        case .finished:
+            return "프로필 교환 성공!"
         }
     }
 }

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/View/ProfileDropViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/AddMate/View/ProfileDropViewController.swift
@@ -74,6 +74,7 @@ final class ProfileDropViewController: BaseViewController, ProfileDropViewable {
         super.viewDidLoad()
         presenter?.viewDidLoad()
     }
+
     override func configureAttributes() {
         configureNavigationControllerAttributes()
         if let gifImageView = GIFImageView(named: Context.profileDropImg) {
@@ -217,6 +218,16 @@ final class ProfileDropViewController: BaseViewController, ProfileDropViewable {
     }
     func changeState(to connectionState: ConnectionState) {
         connectionStateLabel.text = connectionState.description
+        switch connectionState {
+        case .failure, .cannotFindPeer, .finished:
+            Task {[weak self] in
+                try await Task.sleep(nanoseconds: 50000000)
+                self?.presenter?.didCloseTheView()
+            }
+            // TODO: -  현진 추가
+        default:
+            break
+        }
     }
     func changeNotSupportedNI() {
         autoProfileDropButton.isHidden = true
@@ -237,7 +248,7 @@ private extension ProfileDropViewController {
         static let title: String = "프로필 드랍"
         static let contentLabel: String = "자동 연결을 이용해\n원하는 메이트의 핸드폰과\n아래의 동작을 수행해 간편하게\n프로필을 주고 받을 수 있습니다."
         static let descriptionLabel: String = "만약 상대 기기가 수동 연결만 지원한다면,\n함께 수동 연결을 시도하세요."
-        static let connectionLabel: String = "연결 상태 표시"
+        static let connectionLabel: String = "연결 버튼을 눌러보세요! \n 자세한 설명이 필요하다면 하단 텍스트를 터치하세요."
         static let notNIContentLabel: String = "수동 연결을 이용해\n원하는 메이트를 직접 선택해\n프로필을 주고 받을 수 있습니다."
         static let notNIDescriptionLabel: String = "수동 연결만 지원하는 경우,\n상대 기기도 함께 수동 연결해야 합니다."
         static let help: String = "기능 관련 자세한 설명을 원하는 경우"

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/MateList/View/MateListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/MateList/View/MateListViewController.swift
@@ -26,6 +26,7 @@ final class MateListViewController: BaseViewController, MateListViewable {
 
     override func viewWillAppear(_ animated: Bool) {
         presenter?.viewWillAppear()
+        setNavigationTitle()
         super.viewWillAppear(animated)
     }
 
@@ -40,9 +41,6 @@ final class MateListViewController: BaseViewController, MateListViewable {
     }
 
     override func configureAttributes() {
-        navigationItem.title = Context.title
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = .always
         setTableView()
     }
 
@@ -114,6 +112,12 @@ final class MateListViewController: BaseViewController, MateListViewable {
         tableView.dataSource = self
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Identifier.mateCellID)
         tableView.separatorStyle = .none
+    }
+    
+    private func setNavigationTitle() {
+        navigationItem.title = Context.title
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.largeTitleDisplayMode = .always
     }
     
 }
@@ -223,3 +227,4 @@ extension MateListViewController: UIViewControllerTransitioningDelegate {
         CardPresentationController(presentedViewController: presented, presenting: presenting)
     }
 }
+

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TargetedProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TargetedProfileDropUseCase.swift
@@ -25,11 +25,7 @@ final class TargetedProfileDropUseCaseImpl: NSObject, TargetedProfileDropUseCase
     var profilePublisher: PassthroughSubject<DogDTO?, Never> = PassthroughSubject()
     var isConnected: PassthroughSubject<ConnectionState, Never> = PassthroughSubject()
     private var timeLimitCancellable: AnyCancellable? = nil
-    private var sendProfileCancellable: AnyCancellable? = nil {
-        willSet {
-            print("sendProfileCancellable: \(newValue)")
-        }
-    }
+    private var sendProfileCancellable: AnyCancellable? = nil 
     var transmissionFlag: Set<String>
     var isTransitioned: Bool = false
     var triedBefore: Bool = false

--- a/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TargetedProfileDropUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/LocalNetworkUseCase/TargetedProfileDropUseCase.swift
@@ -24,8 +24,12 @@ protocol TargetedProfileDropUseCase {
 final class TargetedProfileDropUseCaseImpl: NSObject, TargetedProfileDropUseCase {
     var profilePublisher: PassthroughSubject<DogDTO?, Never> = PassthroughSubject()
     var isConnected: PassthroughSubject<ConnectionState, Never> = PassthroughSubject()
-    private var cancellable: AnyCancellable? = nil
-
+    private var timeLimitCancellable: AnyCancellable? = nil
+    private var sendProfileCancellable: AnyCancellable? = nil {
+        willSet {
+            print("sendProfileCancellable: \(newValue)")
+        }
+    }
     var transmissionFlag: Set<String>
     var isTransitioned: Bool = false
     var triedBefore: Bool = false
@@ -75,15 +79,16 @@ final class TargetedProfileDropUseCaseImpl: NSObject, TargetedProfileDropUseCase
     }
     
     func execute()  {
+        timeLimitCancellable?.cancel()
         triedBefore = true
         mpcManager.isAvailableToBeConnected.send(true)
         
-        cancellable = Timer.publish(every: Context.connectionTimeLimit, on: .current, in: .common)
+        timeLimitCancellable = Timer.publish(every: Context.connectionTimeLimit, on: .current, in: .common)
             .autoconnect()
             .sink { _ in
                 Task { [weak self] in
                     self?.isConnected.send(.cannotFindPeer)
-                    self?.cancellable?.cancel()
+                    self?.timeLimitCancellable?.cancel()
                 }
             }
     }
@@ -118,6 +123,43 @@ final class TargetedProfileDropUseCaseImpl: NSObject, TargetedProfileDropUseCase
     func mcBrowserViewController() -> MCBrowserViewController {
         mpcManager.serviceBrowser
     }
+    func bindTimer() {
+        timeLimitCancellable?.cancel()
+        
+        sendProfileCancellable = Timer.publish(every: Context.minimumDuration, on: .main, in: .common)
+            .autoconnect()
+            .sink { _ in
+                Task { [weak self] in
+                    // connectedPeer가 없거나 수신플래그를 받으면 타이머 종료
+                    self?.checkProfileDropEnd()
+                    guard let profileData = self?.profileData else { return }
+                    await self?.mpcManager.send(data: profileData)
+                }
+            }
+        timeLimitCancellable = Timer.publish(every: Context.connectionTimeLimit, on: .main, in: .common).autoconnect()
+            .sink { _ in
+                Task { [weak self] in
+                    // connectedPeer가 없거나 수신플래그를 받으면 타이머 종료
+                    self?.isConnected.send(.failure)
+                    self?.timeLimitCancellable?.cancel()
+                }
+            }
+    }
+    func checkProfileDropEnd() {
+        Task { [weak self] in
+            guard await self?.mpcManager.connectedPeerManager.connectedPeer != nil &&
+                    self?.transmissionFlag.contains(Context.peerReceived) != true else {
+                self?.sendProfileCancellable?.cancel()
+                return
+            }
+        }
+        if transmissionFlag.contains(Context.peerReceived) == true
+            && isTransitioned == true {
+            mpcManager.isAvailableToBeConnected.send(false)
+            isConnected.send(.finished)
+            mpcManager.session.disconnect()
+        }
+    }
 }
 // MARK: - MCSessionDelegate
 extension TargetedProfileDropUseCaseImpl: MCSessionDelegate {
@@ -131,25 +173,19 @@ extension TargetedProfileDropUseCaseImpl: MCSessionDelegate {
                 SNMLogger.log("successfully connected to MPCSession: \(session.connectedPeers) session \(session)")
                 await self?.mpcManager.connectedPeerManager.connect(peer: peerID)
                 self?.isConnected.send(.successMPCSession)
+                
+                guard let profileData = self?.profileData else { return }
+                await self?.mpcManager.send(data: profileData)
             }
-            cancellable?.cancel()
-            cancellable = Timer.publish(every: Context.profileSendDuration, on: .current, in: .common)
-                .autoconnect()
-                .sink { _ in
-                    Task { [weak self] in
-                        // connectedPeer가 없거나 수신플래그를 받으면 타이머 종료
-                        guard await self?.mpcManager.connectedPeerManager.connectedPeer != nil
-                                && self?.transmissionFlag.contains(Context.peerReceived) != true else { self?.cancellable?.cancel(); return }
-                        
-                        guard let profileData = self?.profileData else { return }
-                        await self?.mpcManager.send(data: profileData)
-                    }
-                }
+            bindTimer()
         case .connecting:
             isConnected.send(.connecting)
         case .notConnected:
-            cancellable?.cancel()
+            sendProfileCancellable?.cancel()
             isConnected.send(.failure)
+            Task { [weak self] in
+                await self?.mpcManager.connectedPeerManager.disconnect()
+            }
         default:
             break
         }
@@ -173,12 +209,8 @@ extension TargetedProfileDropUseCaseImpl: MCSessionDelegate {
             } catch {
                 SNMLogger.error("Failed to decode received data: \(error)")
             }
-            if self?.transmissionFlag.contains(Context.peerReceived) == true
-                && self?.isTransitioned == true {
-                self?.mpcManager.isAvailableToBeConnected.send(false)
-                session.disconnect()
-            }
         }
+        checkProfileDropEnd()
     }
 
     func session(
@@ -212,7 +244,7 @@ extension TargetedProfileDropUseCaseImpl {
     private enum Context {
         static let received: String = "received"
         static let peerReceived: String = "나 받았어"
-        static let profileSendDuration: Double = 2.0
+        static let minimumDuration: Double = 1.0
         static let connectionTimeLimit: Double = 30.0
     }
 }

--- a/SniffMeet/SniffMeet/Source/UseCase/RespondUseCase/RespondMateRequestUseCase.swift
+++ b/SniffMeet/SniffMeet/Source/UseCase/RespondUseCase/RespondMateRequestUseCase.swift
@@ -44,12 +44,12 @@ struct RespondMateRequestUseCaseImpl: RespondMateRequestUseCase {
             mateList.append(mateId)
             mateList = Array(Set(mateList))
             let mateListData = try encoder.encode(MateListDTO(mates: mateList))
-            try await remoteDBManager.insertData()
+            try await remoteDBManager.updateData()
                 .setTable(Environment.SupabaseTableName.matelist)
                 .setData(mateListData)
                 .setQuery(.equal("id", userID))
                 .request()
-            
+        
             try localDataManager.storeData(data:mateList, key: Environment.UserDefaultsKey.mateList)
         } catch {
             SNMLogger.error("AcceptMateRequestUsecaseError: \(error.localizedDescription)")


### PR DESCRIPTION
### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- [x]  MPCBroswerViewController가 present된 상태에서 connectionState가 바뀐다면 dismiss하는 로직 ( connected, connecting 상태에서 프로필 데이터를 올바르게 받기 위함)
- [x] connectionState를 .finished 추가했습니다. 
- [x] .finished, .failure, .notFoundPeer일 때 프로필 드랍 페이지를 dismiss하도록 했습니다. 
- [x] 연결 시작할 때 30초 동안 연결이 안되거나 연결이 되고 30초 동안 프로필 교환이 안되면 실패처리 
