### PR TITLE
[refactor] 프로젝트 내부 이미지 네이밍 통일

### DIFF
--- a/SniffMeet/SNMSceneTests/MateListScene/UseCaseMock.swift
+++ b/SniffMeet/SNMSceneTests/MateListScene/UseCaseMock.swift
@@ -19,10 +19,12 @@ struct RequestMateListUsecaseMock: RequestMateListUsecase {
     
     func execute(page: Int, pageSize: Int) async throws -> [Mate] {
         mateList.map{
-            Mate(name: $0.dogName,
-                 userID: $0.id,
-                 keywords: $0.keywords,
-                 profileImageURLString: $0.profileImageURL)
+            Mate(
+                name: $0.dogName,
+                userID: $0.id,
+                keywords: $0.keywords,
+                profileImageName: $0.profileImageName
+            )
         }
     }
 }

--- a/SniffMeet/SNMSceneTests/WalkLogScene/WalkLogUsecaseTests.swift
+++ b/SniffMeet/SNMSceneTests/WalkLogScene/WalkLogUsecaseTests.swift
@@ -17,21 +17,21 @@ final class WalkLogUsecaseTests: XCTestCase {
             distance: 200,
             startDate: Date(),
             endDate: Date().addingTimeInterval(300),
-            image: nil
+            imageData: nil
         ),
         WalkLog(
             step: 100,
             distance: 200,
             startDate: Date(),
             endDate: Date().addingTimeInterval(100),
-            image: nil
+            imageData: nil
         ),
         WalkLog(
             step: 100,
             distance: 200,
             startDate: Date(),
             endDate: Date().addingTimeInterval(200),
-            image: nil
+            imageData: nil
         )
     ]
 
@@ -56,7 +56,7 @@ final class WalkLogUsecaseTests: XCTestCase {
             distance: 0,
             startDate: Date(),
             endDate: endDate,
-            image: nil
+            imageData: nil
         )
         // Act
         try saveWalkLogUsecase.execute(walkLog: walkLog)
@@ -75,7 +75,7 @@ final class WalkLogUsecaseTests: XCTestCase {
             distance: 0,
             startDate: Date(),
             endDate: endDate,
-            image: nil
+            imageData: nil
         )
         // Act
         try saveWalkLogUsecase.execute(walkLog: walkLog)

--- a/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
+++ b/SniffMeet/SniffMeet/Source/Common/Constant/Environment.swift
@@ -9,8 +9,8 @@ import Foundation
 
 enum Environment {
     enum UserDefaultsKey {
-        static let profileImage: String = "profileImage"
-        static let dogInfo: String = "dogInfo"
+        static let profileImageName: String = "profileImage"
+        static let profileInfo: String = "dogInfo"
         static let sessionUserInfo: String = "sessionUserInfo"
         static let expiresAt: String = "expiresAt"
         static let mateList: String = "mateList"

--- a/SniffMeet/SniffMeet/Source/Core/LocalNetwork/MPC/MPCManager.swift
+++ b/SniffMeet/SniffMeet/Source/Core/LocalNetwork/MPC/MPCManager.swift
@@ -46,7 +46,7 @@ final class MPCManager: NSObject {
     }
     convenience init?(dataManager: DataLoadable) {
         guard let dog = try? dataManager.loadData(
-            forKey: Environment.UserDefaultsKey.dogInfo,
+            forKey: Environment.UserDefaultsKey.profileInfo,
             type: ProfileInfo.self
         ) else { return nil }
         let myName: String = "\(dog.name)의 \(dog.nickname)"

--- a/SniffMeet/SniffMeet/Source/Core/Supabase/Storage/SupabaseStorageRequest.swift
+++ b/SniffMeet/SniffMeet/Source/Core/Supabase/Storage/SupabaseStorageRequest.swift
@@ -10,6 +10,8 @@ import Foundation
 enum SupabaseStorageRequest {
     case upload(
         accessToken: String,
+        // TODO: 쿼리 구성 개선 작업시 수정
+        // imageData: Data,
         image: Data,
         fileName: String,
         mimeType: MimeType

--- a/SniffMeet/SniffMeet/Source/Entity/DTO/DogProfileDTO.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/DTO/DogProfileDTO.swift
@@ -11,13 +11,13 @@ struct DogProfileDTO: Codable {
     let id: UUID
     let name: String
     let keywords: [Keyword]
-    var profileImage: Data?
+    var profileImageData: Data?
     
-    init(id: UUID, name: String, keywords: [Keyword], profileImage: Data? = nil) {
+    init(id: UUID, name: String, keywords: [Keyword], profileImageData: Data? = nil) {
         self.id = id
         self.name = name
         self.keywords = keywords
-        self.profileImage = profileImage
+        self.profileImageData = profileImageData
     }
     init(dogDTO: DogDTO) {
         id = dogDTO.id
@@ -30,12 +30,14 @@ struct DogDTO: Codable {
     let id: UUID
     let name: String
     let keywords: [Keyword]
-    var profileImage: String?
+    var profileImageName: String?
 }
 
 extension DogProfileDTO {
-    static var example: DogProfileDTO = DogProfileDTO(id: UUID(uuidString: "4a8c392f-24af-4fbf-9043-11b4dd4c131b") ?? .init(),
-                                                      name: "두식",
-                                                      keywords: [.energetic, .friendly],
-                                                      profileImage: nil)
+    static var example: DogProfileDTO = DogProfileDTO(
+        id: UUID(uuidString: "4a8c392f-24af-4fbf-9043-11b4dd4c131b") ?? .init(),
+        name: "두식",
+        keywords: [.energetic, .friendly],
+        profileImageData: nil
+    )
 }

--- a/SniffMeet/SniffMeet/Source/Entity/DTO/UserInfoDTO.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/DTO/UserInfoDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Supabase 서버와 주고받을 유저의 정보입니다. DTO로 사용할 수 있습니다.
 /// id: Supabase DB Table의 row에 접근한 권한이 있는지 확인하려면(RLS) id가 필요합니다.
-/// profileImageURL: 프로필 이미지의 이름입니다.
+/// profileImageName: 프로필 이미지의 이름입니다.
 struct UserInfoDTO: Codable {
     let id: UUID
     let dogName: String
@@ -19,14 +19,15 @@ struct UserInfoDTO: Codable {
     let size: Size
     let keywords: [Keyword]
     let nickname: String
-    let profileImageURL: String?
+    let profileImageName: String?
 
     enum CodingKeys: String, CodingKey {
         case id, age, sex, size, keywords, nickname
         case dogName = "dog_name"
         case sexUponIntake = "sex_upon_intake"
-        case profileImageURL = "profile_image_url"
+        case profileImageName = "profile_image_url"
     }
+    
     func toEntity() -> ProfileInfo {
         ProfileInfo(name: dogName,
                  age: age,

--- a/SniffMeet/SniffMeet/Source/Entity/Mate.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/Mate.swift
@@ -11,7 +11,7 @@ struct Mate {
     var name: String
     var userID: UUID
     var keywords: [Keyword]
-    var profileImageURLString: String?
+    var profileImageName: String?
 }
 
 extension Mate {
@@ -19,6 +19,6 @@ extension Mate {
         name: "후추",
         userID: UUID(),
         keywords: [.shy],
-        profileImageURLString: nil
+        profileImageName: nil
     )
 }

--- a/SniffMeet/SniffMeet/Source/Entity/WalkLog.swift
+++ b/SniffMeet/SniffMeet/Source/Entity/WalkLog.swift
@@ -12,7 +12,7 @@ struct WalkLog: Codable, Equatable {
     let distance: Double
     let startDate: Date
     let endDate: Date
-    let image: Data?
+    let imageData: Data?
 
     var duration: TimeInterval {
         endDate.timeIntervalSince(startDate)

--- a/SniffMeet/SniffMeet/Source/Scene/Auth/SetProfileInfo/Interactor/ProfileSetInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Auth/SetProfileInfo/Interactor/ProfileSetInteractor.swift
@@ -37,6 +37,8 @@ final class ProfileSetInteractor: ProfileSetInteractable {
         Task {
             let profileImageName = try await saveProfileImageUsecase.execute(imageData: imageData)
             try await updateUserInfoUsecase.execute(
+                // TODO: Supabase 테이블 어트리뷰트 이름 조정 후 변경
+                // with: ["nickname": nickname, "profile_image_name": profileImageName]
                 with: ["nickname": nickname, "profile_image_url": profileImageName]
             )
         }

--- a/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Interactor/ProfileEditInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Interactor/ProfileEditInteractor.swift
@@ -46,8 +46,8 @@ final class ProfileEditInteractor: ProfileEditInteractable {
     func requestProfile() -> (ProfileInfo, Data?) {
         do {
             let profileInfo = try loadUserInfoUsecase.execute()
-            let profileImage = try loadUserProfileImageUsecase.execute()
-            return (profileInfo, profileImage)
+            let profileImageData = try loadUserProfileImageUsecase.execute()
+            return (profileInfo, profileImageData)
         } catch {
             // FIXME: 에러 핸들링 필요
             return (ProfileInfo.example, nil)

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/MateList/Interactor/MateListInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/MateList/Interactor/MateListInteractor.swift
@@ -48,10 +48,10 @@ final class MateListInteractor: MateListInteractable {
 
         await withTaskGroup(of: (UUID, Data?).self) { [weak self] group in
             for mate in mates {
-                guard let profileImageURLString = mate.profileImageURLString else { continue }
+                guard let profileImageName = mate.profileImageName else { continue }
                 group.addTask {
                     let imageData = await self?.requestProfileImageUsecase.execute(
-                        fileName: "thumbnail_\(profileImageURLString)"
+                        fileName: "thumbnail_\(profileImageName)"
                     )
                     return (mate.userID, imageData)
                 }

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/ReportMate/Interactor/ReportMateInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/ReportMate/Interactor/ReportMateInteractor.swift
@@ -35,7 +35,7 @@ final class ReportMateInteractor: ReportMateInteractable {
     }
     func requestProfileImage(imageName: String?) {
         Task {
-            let fileName = mate.profileImageURLString ?? ""
+            let fileName = mate.profileImageName ?? ""
             guard let imageData = await requestProfileImageUsecase.execute(fileName: fileName) else { return }
             presenter?.didFetchProfileImage(data: imageData)
         }

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/ReportMate/Presenter/ReportMatePresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/ReportMate/Presenter/ReportMatePresenter.swift
@@ -75,7 +75,7 @@ final class ReportMatePresenter: ReportMatePresentable {
 extension ReportMatePresenter: ReportMateInteractorOutput {
     func didFetchMateInfo(mateInfo: Mate?) {
         output.mateInfo.send(mateInfo)
-        if let profileImageName = mateInfo?.profileImageURLString {
+        if let profileImageName = mateInfo?.profileImageName {
             interactor?.requestProfileImage(imageName: profileImageName)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/RequestMate/View/RequestMateViewController.swift
@@ -31,7 +31,7 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
 
     init(dogDTO: DogDTO) {
         profile = DogProfileDTO(dogDTO: dogDTO)
-        imageURL = dogDTO.profileImage
+        imageURL = dogDTO.profileImageName
         super.init()
     }
 
@@ -43,7 +43,7 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
     }
 
     override func configureAttributes() {
-        configureProfileImage(imageData: profile.profileImage)
+        configureProfileImage(imageData: profile.profileImageData)
         nameLabel.text = profile.name
         nameLabel.textColor = SNMColor.white
         nameLabel.font = SNMFont.title1

--- a/SniffMeet/SniffMeet/Source/Scene/Mate/RequestMate/View/RequestMateViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Mate/RequestMate/View/RequestMateViewController.swift
@@ -26,19 +26,19 @@ final class RequestMateViewController: BaseViewController, RequestMateViewable {
     private var acceptButton = PrimaryButton(title: Context.acceptTitle)
     private var keywords: [Keyword] = []
     private var profile: DogProfileDTO
-    private let imageURL: String?
+    private let imageName: String?
     private var cancellables = Set<AnyCancellable>()
 
     init(dogDTO: DogDTO) {
         profile = DogProfileDTO(dogDTO: dogDTO)
-        imageURL = dogDTO.profileImageName
+        imageName = dogDTO.profileImageName
         super.init()
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if let imageURL {
-            presenter?.viewDidLoad(fileName: imageURL)
+        if let imageName {
+            presenter?.viewDidLoad(fileName: imageName)
         }
     }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/RequestWalk/Interactor/RequestWalkInteractor.swift
@@ -69,7 +69,7 @@ final class RequestWalkInteractor: RequestWalkInteractable {
     
     func requestProfileImage(imageName: String?) {
         Task { @MainActor in
-            let fileName = mate.profileImageURLString ?? ""
+            let fileName = mate.profileImageName ?? ""
             let imageData = await requestProfileImageUsecase.execute(fileName: fileName)
             presenter?.didFetchProfileImage(imageData: imageData)
         }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/RequestWalk/Presenter/RequestWalkPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/RequestWalk/Presenter/RequestWalkPresenter.swift
@@ -79,7 +79,7 @@ final class RequestWalkPresenter: RequestWalkPresentable {
 extension RequestWalkPresenter: RequestWalkInteractorOutput {
     func didFetchMateInfo(mateInfo: Mate) {
         output.mateInfo.send(mateInfo)
-        if let profileImageName = mateInfo.profileImageURLString {
+        if let profileImageName = mateInfo.profileImageName {
             interactor?.requestProfileImage(imageName: profileImageName)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/RespondWalk/Interactor/ProcessedWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/RespondWalk/Interactor/ProcessedWalkInteractor.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol ProcessedWalkInteractable: AnyObject {
     var presenter: (any ProcessedWalkInteractorOutput)? { get set }
     func fetchSenderInfo(userID: UUID)
-    func fetchProfileImage(urlString: String)
+    func fetchProfileImage(named imageName: String)
     func convertLocationToText(latitude: Double, longtitude: Double)
 }
 
@@ -44,16 +44,16 @@ final class ProcessedWalkInteractor: ProcessedWalkInteractable {
                     return
                 }
                 presenter?.didFetchUserInfo(senderInfo: senderInfo)
-                guard let profileImageURL = senderInfo.profileImageURL else { return }
-                fetchProfileImage(urlString: profileImageURL)
+                guard let profileImageName = senderInfo.profileImageName else { return }
+                fetchProfileImage(named: profileImageName)
             } catch {
                 presenter?.didFailToFetchWalkRequest(error: error)
             }
         }
     }
-    func fetchProfileImage(urlString: String) {
+    func fetchProfileImage(named imageName: String) {
         Task { [weak self] in
-            let imageData = try await self?.requestProfileImageUsecase.execute(fileName: urlString)
+            let imageData = await self?.requestProfileImageUsecase.execute(fileName: imageName)
             self?.presenter?.didFetchProfileImage(with: imageData)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/RespondWalk/Interactor/RespondWalkInteractor.swift
@@ -20,7 +20,7 @@ protocol RespondWalkInteractable: AnyObject {
     func respondWalkRequest(isAccepted: Bool, receivedNoti: WalkNoti)
     func calculateTimeLimit(requestTime: Date)
     func convertLocationToText(latitude: Double, longtitude: Double) async
-    func fetchProfileImage(urlString: String)
+    func fetchProfileImage(named imageName: String)
 }
 
 final class RespondWalkInteractor: RespondWalkInteractable {
@@ -62,8 +62,8 @@ final class RespondWalkInteractor: RespondWalkInteractable {
                     return
                 }
                 presenter?.didFetchUserInfo(senderInfo: senderInfo)
-                guard let profileImageURL = senderInfo.profileImageURL else { return }
-                fetchProfileImage(urlString: profileImageURL)
+                guard let profileImageName = senderInfo.profileImageName else { return }
+                fetchProfileImage(named: profileImageName)
             } catch {
                 presenter?.didFailToFetchWalkRequest(error: error)
             }
@@ -111,9 +111,9 @@ final class RespondWalkInteractor: RespondWalkInteractable {
             presenter?.didConvertLocationToText(with: locationText)
         }
     }
-    func fetchProfileImage(urlString: String) {
+    func fetchProfileImage(named imageName: String) {
         Task { [weak self] in
-            let imageData = try await self?.requestProfileImageUsecase.execute(fileName: urlString)
+            let imageData = await self?.requestProfileImageUsecase.execute(fileName: imageName)
             self?.presenter?.didFetchProfileImage(with: imageData)
         }
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/TrackWalk/Interactor/TrackWalkInteractor.swift
@@ -114,7 +114,7 @@ final class TrackWalkInteractor: TrackWalkInteractable {
             distance: totalDistance,
             startDate: startDate,
             endDate: endDate,
-            image: snapshotImageData
+            imageData: snapshotImageData
         )
     }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Walk/WalkLog/WalkLogList/View/WalkLogListViewController.swift
@@ -133,7 +133,7 @@ extension WalkLogListViewController: UITableViewDataSource {
             step: "\(walkLogs[indexPath.row].step) 걸음",
             duration: durationLabelString(walkLogs[indexPath.row].duration),
             image: UIImage(
-                data: walkLogs[indexPath.row].image ?? Data()
+                data: walkLogs[indexPath.row].imageData ?? Data()
             )
         )
         cell.configureProfileSection(

--- a/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/NearByProfileDropUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/NearByProfileDropUsecase.swift
@@ -107,15 +107,16 @@ final class NearByProfileDropUsecaseImpl: NSObject, NearByProfileDropUsecase {
                 forKey: Environment.UserDefaultsKey.profileInfo,
                 type: ProfileInfo.self)
             let userID = try SupabaseSessionManager.shared.userID.get()
-            let imageURL = try? dataManager.loadData(
+            let imageName = try? dataManager.loadData(
                 forKey: Environment.UserDefaultsKey.profileImageName,
                 type: String.self
             )
 
-            let dogProfile = DogDTO(id: userID,
+            let dogProfile = DogDTO(
+                id: userID,
                 name: dog.name,
                 keywords: dog.keywords,
-                profileImageName: imageURL
+                profileImageName: imageName
             )
             let profileDropDTO = MPCProfileDropDTO(
                 token: nil,

--- a/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/NearByProfileDropUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/NearByProfileDropUsecase.swift
@@ -104,11 +104,11 @@ final class NearByProfileDropUsecaseImpl: NSObject, NearByProfileDropUsecase {
     func loadProfileData() {
         do {
             let dog = try dataManager.loadData(
-                forKey: Environment.UserDefaultsKey.dogInfo,
+                forKey: Environment.UserDefaultsKey.profileInfo,
                 type: ProfileInfo.self)
             let userID = try SupabaseSessionManager.shared.userID.get()
             let imageURL = try? dataManager.loadData(
-                forKey: Environment.UserDefaultsKey.profileImage,
+                forKey: Environment.UserDefaultsKey.profileImageName,
                 type: String.self
             )
 

--- a/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/NearByProfileDropUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/NearByProfileDropUsecase.swift
@@ -115,7 +115,7 @@ final class NearByProfileDropUsecaseImpl: NSObject, NearByProfileDropUsecase {
             let dogProfile = DogDTO(id: userID,
                 name: dog.name,
                 keywords: dog.keywords,
-                profileImage: imageURL
+                profileImageName: imageURL
             )
             let profileDropDTO = MPCProfileDropDTO(
                 token: nil,

--- a/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/TargetedProfileDropUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/TargetedProfileDropUsecase.swift
@@ -109,7 +109,7 @@ final class TargetedProfileDropUsecaseImpl: NSObject, TargetedProfileDropUsecase
             let dogProfile = DogDTO(id: userID,
                 name: dog.name,
                 keywords: dog.keywords,
-                profileImage: imageURL
+                profileImageName: imageURL
             )
             let profileDropDTO = MPCProfileDropDTO(
                 token: nil,

--- a/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/TargetedProfileDropUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/TargetedProfileDropUsecase.swift
@@ -97,12 +97,12 @@ final class TargetedProfileDropUsecaseImpl: NSObject, TargetedProfileDropUsecase
     func loadProfileData() {
         do {
             let dog = try dataManager.loadData(
-                forKey: Environment.UserDefaultsKey.dogInfo,
+                forKey: Environment.UserDefaultsKey.profileInfo,
                 type: ProfileInfo.self
             )
             guard let userID = try? SupabaseSessionManager.shared.userID.get() else { return }
             let imageURL = try? dataManager.loadData(
-                forKey: Environment.UserDefaultsKey.profileImage,
+                forKey: Environment.UserDefaultsKey.profileImageName,
                 type: String.self
             )
 

--- a/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/TargetedProfileDropUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/LocalNetworkUsecase/TargetedProfileDropUsecase.swift
@@ -101,15 +101,16 @@ final class TargetedProfileDropUsecaseImpl: NSObject, TargetedProfileDropUsecase
                 type: ProfileInfo.self
             )
             guard let userID = try? SupabaseSessionManager.shared.userID.get() else { return }
-            let imageURL = try? dataManager.loadData(
+            let imageName = try? dataManager.loadData(
                 forKey: Environment.UserDefaultsKey.profileImageName,
                 type: String.self
             )
 
-            let dogProfile = DogDTO(id: userID,
+            let dogProfile = DogDTO(
+                id: userID,
                 name: dog.name,
                 keywords: dog.keywords,
-                profileImageName: imageURL
+                profileImageName: imageName
             )
             let profileDropDTO = MPCProfileDropDTO(
                 token: nil,

--- a/SniffMeet/SniffMeet/Source/Usecase/RequestUsecase/LoadUserInfoUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/RequestUsecase/LoadUserInfoUsecase.swift
@@ -20,7 +20,7 @@ struct LoadUserInfoUsecaseImpl: LoadUserInfoUsecase {
 
     func execute() throws -> ProfileInfo {
         let profileInfo = try dataLoadable.loadData(
-            forKey: Environment.UserDefaultsKey.dogInfo,
+            forKey: Environment.UserDefaultsKey.profileInfo,
             type: ProfileInfo.self
         )
         return profileInfo

--- a/SniffMeet/SniffMeet/Source/Usecase/RequestUsecase/LoadUserProfileImageUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/RequestUsecase/LoadUserProfileImageUsecase.swift
@@ -19,9 +19,9 @@ struct LoadUserProfileImageImpl: LoadUserProfileImageUsecase {
     }
 
     func execute() throws -> Data? {
-        let profileImage = try? imageManageable.get(
+        let profileImageData = try? imageManageable.get(
             forKey: Environment.FileManagerKey.profileImage
         )
-        return profileImage
+        return profileImageData
     }
 }

--- a/SniffMeet/SniffMeet/Source/Usecase/RequestUsecase/RequestMateListUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/RequestUsecase/RequestMateListUsecase.swift
@@ -39,10 +39,12 @@ struct RequestMateListUsecaseImpl: RequestMateListUsecase {
                 .request()
             let mateDTOList = try jsonDecoder.decode([UserInfoDTO].self, from: data)
             return mateDTOList.map {
-                Mate(name: $0.dogName,
-                     userID: $0.id,
-                     keywords: $0.keywords,
-                     profileImageURLString: $0.profileImageURL)
+                Mate(
+                    name: $0.dogName,
+                    userID: $0.id,
+                    keywords: $0.keywords,
+                    profileImageName: $0.profileImageName
+                )
             }
         } catch let error as SupabaseSessionError {
             throw SNMError(level: .notExistSession, error: error)

--- a/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/SaveProfileImageUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/SaveProfileImageUsecase.swift
@@ -97,7 +97,7 @@ struct SaveProfileImageUsecaseImpl: SaveProfileImageUsecase {
     private func saveToLocal(fileName: String, imageData: Data) throws {
         try localDataManager.set(
             value: fileName,
-            forKey: Environment.UserDefaultsKey.profileImage
+            forKey: Environment.UserDefaultsKey.profileImageName
         )
         try fileManager.set(
             value: imageData,

--- a/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/SaveUserInfoUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/SaveUserInfoUsecase.swift
@@ -41,7 +41,7 @@ struct SaveUserInfoUsecaseImpl: SaveUserInfoUsecase {
                 size: userInfo.size,
                 keywords: userInfo.keywords,
                 nickname: userInfo.nickname,
-                profileImageURL: nil
+                profileImageName: nil
             )
             try await saveToRemote(dto: dto)
         } catch let error as UserDefaultsError {

--- a/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/SaveUserInfoUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/SaveUserInfoUsecase.swift
@@ -47,15 +47,15 @@ struct SaveUserInfoUsecaseImpl: SaveUserInfoUsecase {
         } catch let error as UserDefaultsError {
             throw SNMError(level: .logOnly, error: error)
         } catch let error as SupabaseSessionError {
-            try localDataManager.delete(forKey: Environment.UserDefaultsKey.dogInfo)
+            try localDataManager.delete(forKey: Environment.UserDefaultsKey.profileInfo)
             throw SNMError(level: .notExistSession, error: error)
         } catch let error as SupabaseDBError {
-            try localDataManager.delete(forKey: Environment.UserDefaultsKey.dogInfo)
+            try localDataManager.delete(forKey: Environment.UserDefaultsKey.profileInfo)
             throw SNMError(level: .retryable, error: error)
         }
     }
     private func saveToLocal(userInfo: ProfileInfo) throws {
-        try localDataManager.set(value: userInfo, forKey: Environment.UserDefaultsKey.dogInfo)
+        try localDataManager.set(value: userInfo, forKey: Environment.UserDefaultsKey.profileInfo)
     }
     private func saveToRemote(dto: UserInfoDTO) async throws {
         let userData = try jsonEncoder.encode(dto)

--- a/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/UpdateUserInfoUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/UpdateUserInfoUsecase.swift
@@ -28,7 +28,7 @@ struct UpdateUserInfoUsecaseImpl: UpdateUserInfoUsecase {
     
     func execute(with updatedProperty: [String: Any]) async throws {
         guard let oldProfileInfo = try? localDataManager.get(
-            forKey: Environment.UserDefaultsKey.dogInfo,
+            forKey: Environment.UserDefaultsKey.profileInfo,
             type: ProfileInfo.self
         ) else {
             throw SNMError(level: .notExistSession, error: UserDefaultsError.notFound)
@@ -39,10 +39,10 @@ struct UpdateUserInfoUsecaseImpl: UpdateUserInfoUsecase {
         } catch let error as UserDefaultsError {
             throw SNMError(level: .retryable, error: error)
         } catch let error as SupabaseSessionError {
-            try localDataManager.set(value: oldProfileInfo, forKey: Environment.UserDefaultsKey.dogInfo)
+            try localDataManager.set(value: oldProfileInfo, forKey: Environment.UserDefaultsKey.profileInfo)
             throw SNMError(level: .notExistSession, error: error)
         } catch let error as SupabaseDBError {
-            try localDataManager.set(value: oldProfileInfo, forKey: Environment.UserDefaultsKey.dogInfo)
+            try localDataManager.set(value: oldProfileInfo, forKey: Environment.UserDefaultsKey.profileInfo)
             throw SNMError(level: .retryable, error: error)
         }
     }
@@ -64,7 +64,7 @@ struct UpdateUserInfoUsecaseImpl: UpdateUserInfoUsecase {
             nickname: oldProfileInfo.nickname,
             profileImageName: oldProfileInfo.profileImageName
         )
-        try localDataManager.set(value: newProfileInfo, forKey: Environment.UserDefaultsKey.dogInfo)
+        try localDataManager.set(value: newProfileInfo, forKey: Environment.UserDefaultsKey.profileInfo)
     }
     private func updateToRemote(with updatedProperty: [String: Any]) async throws {
         let userID = try sessionManager.userID.get()


### PR DESCRIPTION
### 🔖  Issue Number

close #80 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
- 유저 디폴트 키 네이밍 직관적으로 변경
- 프로필 이미지 관련 프로퍼티 네이밍 통일
    - profileImageName, profileImageURL, profileImageURLString, profileImage등... 동일한 용도의 값을 저장하지만, 파편화 되어 있던 프로퍼티명을 통일했습니다.

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- 기능 추가, 변경, 삭제는 없습니다. 다만 네이밍이 약간 변경되었습니다.
    - 네이밍을 변경하면서 고민한 부분은 개발 일지에 정리했습니다. 아래 레퍼런스에 적어놓겠습니다.
- 팀에서 생각했으면 좋을 부분
헝가리안 표기법과 유사해지는 것 같아 거부감이 있을 수 있지만, ‘같은 정보’를 다양한 타입으로 표기하는 경우가 많아서 어느 정도는 프로퍼티명에 타입을 유추할 수 있는 정보가 있었으면 좋겠습니다.
예를 들어:
    - 이름에 ‘URL’이 붙은 프로퍼티가 `String`타입, `URL`타입인 경우가 혼재됩니다.
        - 개인적으로 URL을 스트링으로 표현할 경우에는 프로퍼티 명을 ‘URLString’을 사용했으면 좋겠습니다.
    - 위에서 말한 것 처럼, ‘Image’ 이름이 붙은 프로퍼티가, `String`, `Data`, `UIImage`등 다양한 타입으로 혼재되어 있었습니다.

### 👻 레퍼런스
- [개발일지](https://check-it.notion.site/1baf6d0576c280a0aeadd52eecbab52b?pvs=4)

