### PR TITLE
[fix] 프로필 업데이트 안되는 문제 해결

### DIFF
--- a/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Interactor/ProfileEditInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Interactor/ProfileEditInteractor.swift
@@ -91,7 +91,7 @@ final class ProfileEditInteractor: ProfileEditInteractable {
         do {
             try await updateUserInfoUsecase.execute(
                 with: [
-                    "name": name,
+                    "dog_name": name,
                     "age": age,
                     "size": size,
                     "keywords": keywords

--- a/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Interactor/ProfileEditInteractor.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Interactor/ProfileEditInteractor.swift
@@ -19,7 +19,7 @@ protocol ProfileEditInteractable: AnyObject {
         size: String,
         keywords: [String],
         imageData: Data?
-    )
+    ) async throws
 }
 
 final class ProfileEditInteractor: ProfileEditInteractable {
@@ -59,26 +59,19 @@ final class ProfileEditInteractor: ProfileEditInteractable {
         size: String,
         keywords: [String],
         imageData: Data?
-    ) {
-        Task {
-            do {
-                try await updateUserInfo(
-                    name: name,
-                    age: age,
-                    size: size,
-                    keywords: keywords
-                )
-                guard let imageData else {
-                    presenter?.didSaveUserInfo()
-                    return
-                }
-                try await saveProfile(imageData: imageData)
-                presenter?.didSaveUserInfo()
-            } catch let error {
-                SNMLogger.error(error.localizedDescription)
-            }
+    ) async throws {
+        try await updateUserInfo(
+            name: name,
+            age: age,
+            size: size,
+            keywords: keywords
+        )
+        if let imageData {
+            try await saveProfile(imageData: imageData)
         }
+        presenter?.didSaveUserInfo()
     }
+    
     private func saveProfile(imageData: Data) async throws {
         let _ = try await saveProfileImageUsecase.execute(imageData: imageData)
     }

--- a/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Presenter/ProfileEditPresenter.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/Presenter/ProfileEditPresenter.swift
@@ -69,13 +69,19 @@ final class ProfileEditPresenter: ProfileEditPresentable {
               let keywords else {
             return
         }
-        interactor?.editUserInfo(
-            name: nameText,
-            age: age,
-            size: size.rawValue,
-            keywords: keywords.map { $0.rawValue },
-            imageData: profileImage?.jpegData(compressionQuality: 0.7)
-        )
+        Task {
+            do {
+                try await interactor?.editUserInfo(
+                    name: nameText,
+                    age: age,
+                    size: size.rawValue,
+                    keywords: keywords.map { $0.rawValue },
+                    imageData: profileImage?.jpegData(compressionQuality: 0.7)
+                )
+            } catch {
+                SNMLogger.error(error.localizedDescription)
+            }
+        }
     }
 }
 

--- a/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/View/ProfileEditViewController.swift
+++ b/SniffMeet/SniffMeet/Source/Scene/Home/EditProfile/View/ProfileEditViewController.swift
@@ -228,8 +228,8 @@ final class ProfileEditViewController: BaseViewController, ProfileEditViewable {
         completeEditButton.publisher(event: .touchUpInside)
             .sink { [weak self] _ in
                 self?.completeEditButton.isEnabled = false
-                self?.snmProgressToast.show(in: self?.view, isDim: true)
                 self?.handleCompleteButtonAction()
+                self?.snmProgressToast.show(in: self?.view, isDim: true)
             }
             .store(in: &cancellables)
     }

--- a/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/UpdateUserInfoUsecase.swift
+++ b/SniffMeet/SniffMeet/Source/Usecase/SaveUsecase/UpdateUserInfoUsecase.swift
@@ -51,7 +51,7 @@ struct UpdateUserInfoUsecaseImpl: UpdateUserInfoUsecase {
         from oldProfileInfo: ProfileInfo
     ) throws {
         let newProfileInfo = ProfileInfo(
-            name: updatedProperty["name"] as? String ?? oldProfileInfo.name,
+            name: updatedProperty["dog_name"] as? String ?? oldProfileInfo.name,
             age: updatedProperty["age"] as? UInt8 ?? oldProfileInfo.age,
             sex: oldProfileInfo.sex,
             sexUponIntake: updatedProperty["sexUponIntake"] as? Bool ?? oldProfileInfo.sexUponIntake,


### PR DESCRIPTION
### 🔖  Issue Number

close #75 

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
> 
<img width="659" alt="Screenshot 2025-04-10 at 3 24 06 AM" src="https://github.com/user-attachments/assets/848bb56f-5f5f-481c-a7e1-f9ce9df40f4e" /> 

 
- JSON 데이터와 Supabase 테이블 간 어트리뷰트 이름 미스매치 수정
    - Postman, 앱 양쪽 모두 업데이트가 잘 동작하는걸 확인했습니다.
- Interactor에 있던 `Task` presenter로 옮기고 코드 리더빌리티 약간 향상
    -  `if let`을 써야할 부분에 `guard let`을 쓴 것을 수정했습니다.
- 토스트 등장 타이밍 변경

### 📝 PR 특이사항 

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
> 
- PR 길이에 비해 트러블 슈팅 문서가 생각보다 깁니다...
- 코드를 재분석 하면서 몇가지 잠재적인 문제들을 발견했습니다.
    - 정확한 원인은 파악하지 못했지만, 토스트 타이밍에 약간 문제가 생길 가능성이 있는 것 같습니다. (이 PR과는 연관이 없어 더 살펴보고 이슈 생성이 필요합니다.)
    - 이미지 열화 문제가 있습니다. 이미지를 변경하지 않더라도 이미지를 넘기고 jpeg으로 압축하기 때문입니다. 

### 👻 레퍼런스
- 깃헙 위키 페이지

